### PR TITLE
Proportional circles and hover state

### DIFF
--- a/src/Map.js
+++ b/src/Map.js
@@ -171,16 +171,16 @@ export class Map extends EventEmitter {
     onMouseMove(evt) {
         const feature = this.getEventFeature(evt)
         let featureId
-        let layerId
-        let featureLayerId
+        let sourceId
+        let featureSourceId
 
         if (feature) {
             featureId = feature.id
-            layerId = feature.layer.id
-            featureLayerId = `${featureId}-${layerId}`
+            sourceId = feature.source
+            featureSourceId = `${featureId}-${sourceId}`
         }
 
-        if (featureLayerId !== this._hoverId) {
+        if (featureSourceId !== this._hoverId) {
             const mapgl = this.getMapGL()
 
             mapgl.getCanvas().style.cursor = feature ? 'pointer' : ''
@@ -194,7 +194,7 @@ export class Map extends EventEmitter {
 
             if (feature) {
                 this._hoverState = {
-                    source: layerId,
+                    source: sourceId,
                     id: featureId,
                 }
 
@@ -202,14 +202,15 @@ export class Map extends EventEmitter {
             }
         }
 
-        this._hoverId = featureLayerId
+        this._hoverId = featureSourceId
     }
 
     // TODO: throttle?
     getEventFeature(evt) {
         const layers = this.getLayers()
             .filter(l => l.isInteractive())
-            .map(l => l.getInteractiveId())
+            .map(l => l.getInteractiveIds())
+            .reduce((out, ids) => [...out, ...ids], [])
         let feature
 
         if (layers.length) {

--- a/src/layers/Boundary.js
+++ b/src/layers/Boundary.js
@@ -36,22 +36,23 @@ class Boundary extends Layer {
     createLayers() {
         const id = this.getId()
 
-        this.setLayer({
-            id,
-            type: 'line',
-            source: id,
-            paint: {
-                'line-color': ['get', 'color'],
-                'line-width': [
-                    'case',
-                    ['boolean', ['feature-state', 'hover'], false],
-                    ['+', ['get', 'weight'], 2],
-                    ['get', 'weight'],
-                ],
+        this.addLayer(
+            {
+                id,
+                type: 'line',
+                source: id,
+                paint: {
+                    'line-color': ['get', 'color'],
+                    'line-width': [
+                        'case',
+                        ['boolean', ['feature-state', 'hover'], false],
+                        ['+', ['get', 'weight'], 2],
+                        ['get', 'weight'],
+                    ],
+                },
             },
-        })
-
-        this.setIteractiveLayerId(id)
+            true
+        )
     }
 
     setOpacity(opacity) {

--- a/src/layers/Choropleth.js
+++ b/src/layers/Choropleth.js
@@ -36,7 +36,7 @@ class Choropleth extends Layer {
         const { label, labelStyle } = this.options
 
         // Polygon layer
-        this.setLayer(
+        this.addLayer(
             {
                 id: `${id}`,
                 type: 'fill',
@@ -51,7 +51,7 @@ class Choropleth extends Layer {
         )
 
         // Point layer
-        this.setLayer(
+        this.addLayer(
             {
                 id: `${id}-point`,
                 type: 'circle',
@@ -68,7 +68,7 @@ class Choropleth extends Layer {
         )
 
         // Polygon hover state
-        this.setLayer({
+        this.addLayer({
             id: `${id}-hover`,
             type: 'line',
             source: id,
@@ -85,7 +85,7 @@ class Choropleth extends Layer {
         })
 
         // Point hover state
-        this.setLayer({
+        this.addLayer({
             id: `${id}-point-hover`,
             type: 'circle',
             source: id,
@@ -104,7 +104,7 @@ class Choropleth extends Layer {
         })
 
         if (label) {
-            this.setLayer(getLabelsLayer(id, label, labelStyle))
+            this.addLayer(getLabelsLayer(id, label, labelStyle))
         }
     }
 

--- a/src/layers/Choropleth.js
+++ b/src/layers/Choropleth.js
@@ -1,11 +1,16 @@
 import Layer from './Layer'
 import { getLablesSource, getLabelsLayer } from '../utils/labels'
 
+const borderColor = '#333'
+const borderWeight = 1
+const hoverBorderWeight = 3
+
 class Choropleth extends Layer {
     constructor(options) {
         super(options)
 
         const { data } = options
+
         this.setFeatures(data)
         this.createSource()
         this.createLayers()
@@ -30,36 +35,77 @@ class Choropleth extends Layer {
         const id = this.getId()
         const { label, labelStyle } = this.options
 
-        this.setLayer({
-            id,
-            type: 'fill',
-            source: id,
-            paint: {
-                'fill-color': ['get', 'color'],
-                'fill-outline-color': '#333',
+        // Polygon layer
+        this.setLayer(
+            {
+                id: `${id}`,
+                type: 'fill',
+                source: id,
+                paint: {
+                    'fill-color': ['get', 'color'],
+                    'fill-outline-color': borderColor,
+                },
+                filter: ['==', '$type', 'Polygon'],
             },
-        })
+            true
+        )
 
+        // Point layer
+        this.setLayer(
+            {
+                id: `${id}-point`,
+                type: 'circle',
+                source: id,
+                paint: {
+                    'circle-color': ['get', 'color'],
+                    'circle-radius': ['get', 'radius'],
+                    'circle-stroke-width': borderWeight,
+                    'circle-stroke-color': borderColor,
+                },
+                filter: ['==', '$type', 'Point'],
+            },
+            true
+        )
+
+        // Polygon hover state
         this.setLayer({
             id: `${id}-hover`,
             type: 'line',
             source: id,
             paint: {
-                'line-color': '#333',
+                'line-color': borderColor,
                 'line-width': [
                     'case',
                     ['boolean', ['feature-state', 'hover'], false],
-                    3,
-                    1,
+                    hoverBorderWeight,
+                    borderWeight,
                 ],
             },
+            filter: ['==', '$type', 'Polygon'],
+        })
+
+        // Point hover state
+        this.setLayer({
+            id: `${id}-point-hover`,
+            type: 'circle',
+            source: id,
+            paint: {
+                'circle-opacity': 0,
+                'circle-radius': ['get', 'radius'],
+                'circle-stroke-width': [
+                    'case',
+                    ['boolean', ['feature-state', 'hover'], false],
+                    hoverBorderWeight,
+                    borderWeight,
+                ],
+                'circle-stroke-color': borderColor,
+            },
+            filter: ['==', '$type', 'Point'],
         })
 
         if (label) {
             this.setLayer(getLabelsLayer(id, label, labelStyle))
         }
-
-        this.setIteractiveLayerId(id)
     }
 
     setOpacity(opacity) {

--- a/src/layers/ClientCluster.js
+++ b/src/layers/ClientCluster.js
@@ -26,7 +26,7 @@ class ClientCluster extends Layer {
     createLayers(color, radius) {
         const id = this.getId()
 
-        this.setLayer({
+        this.addLayer({
             id: `${id}-clusters`,
             type: 'circle',
             source: id,
@@ -49,7 +49,7 @@ class ClientCluster extends Layer {
             },
         })
 
-        this.setLayer({
+        this.addLayer({
             id: `${id}-count`,
             type: 'symbol',
             source: id,
@@ -64,7 +64,7 @@ class ClientCluster extends Layer {
             },
         })
 
-        this.setLayer({
+        this.addLayer({
             id,
             type: 'circle',
             source: id,

--- a/src/layers/Dots.js
+++ b/src/layers/Dots.js
@@ -23,7 +23,7 @@ class Dots extends Layer {
     createLayers(radius) {
         const id = this.getId()
 
-        this.setLayer({
+        this.addLayer({
             id,
             type: 'circle',
             source: id,

--- a/src/layers/EarthEngine.js
+++ b/src/layers/EarthEngine.js
@@ -35,7 +35,7 @@ class EarthEngine extends Layer {
             tileSize: 256,
         })
 
-        this.setLayer({
+        this.addLayer({
             id: this.getId(),
             type: 'raster',
             source: this.getId(),
@@ -159,7 +159,7 @@ class EarthEngine extends Layer {
     createLayer() {
         console.log('create layer')
 
-        this.setLayer({
+        this.addLayer({
             id: this.getId(),
             type: 'raster',
             source: this.getId(),

--- a/src/layers/Layer.js
+++ b/src/layers/Layer.js
@@ -3,8 +3,6 @@ import EventEmitter from 'events'
 import bbox from '@turf/bbox'
 import { addImages } from '../utils/images'
 
-const polygonTypes = ['Polygon', 'MultiPolygon']
-
 class Layer extends EventEmitter {
     constructor(options = {}) {
         super()
@@ -149,19 +147,6 @@ class Layer extends EventEmitter {
             type: 'FeatureCollection',
             features: this._features,
         }
-    }
-
-    getPolygonFeatures() {
-        return {
-            type: 'FeatureCollection',
-            features: this._features.filter(f =>
-                polygonTypes.includes(f.geometry.type)
-            ),
-        }
-    }
-
-    getPointFeatures() {
-        return this._features
     }
 
     // Adds integer id for each feature (required by Feature State)

--- a/src/layers/Layer.js
+++ b/src/layers/Layer.js
@@ -102,7 +102,9 @@ class Layer extends EventEmitter {
     }
 
     isInteractive() {
-        return this._interactiveIds.length && this.isOnMap() && this.isVisible()
+        return (
+            !!this._interactiveIds.length && this.isOnMap() && this.isVisible()
+        )
     }
 
     setSource(id, source) {
@@ -113,15 +115,11 @@ class Layer extends EventEmitter {
         return this._source
     }
 
-    setIteractiveLayerId(id) {
-        this._interactiveIds.push(id)
-    }
-
     getInteractiveIds() {
-        return this.isInteractive() ? this._interactiveIds : null
+        return this.isInteractive() ? this._interactiveIds : []
     }
 
-    setLayer(layer, isInteractive) {
+    addLayer(layer, isInteractive) {
         this._layers.push(layer)
 
         if (isInteractive) {
@@ -134,7 +132,7 @@ class Layer extends EventEmitter {
     }
 
     hasLayerId(id) {
-        return this.getLayers().find(layer => layer.id === id)
+        return this.getLayers().some(layer => layer.id === id)
     }
 
     moveToTop() {

--- a/src/layers/Markers.js
+++ b/src/layers/Markers.js
@@ -48,7 +48,7 @@ class Markers extends Layer {
         const { buffer, bufferStyle, label, labelStyle } = this.options
 
         if (buffer) {
-            this.setLayer(getCirclesLayer(id, bufferStyle))
+            this.addLayer(getCirclesLayer(id, bufferStyle))
         }
 
         const config = {
@@ -67,7 +67,7 @@ class Markers extends Layer {
             addTextProperties(config, label, labelStyle)
         }
 
-        this.setLayer(config)
+        this.addLayer(config)
     }
 
     setOpacity(opacity) {

--- a/src/layers/TileLayer.js
+++ b/src/layers/TileLayer.js
@@ -27,7 +27,7 @@ class TileLayer extends Layer {
     }
 
     createLayer() {
-        this.setLayer({
+        this.addLayer({
             id: this.getId(),
             type: 'raster',
             source: this.getId(),

--- a/src/layers/__tests__/Layer.spec.js
+++ b/src/layers/__tests__/Layer.spec.js
@@ -5,6 +5,7 @@ jest.mock('../../utils/images')
 const mockMapGL = {
     addLayer: jest.fn(),
     addSource: jest.fn(),
+    getLayer: jest.fn(),
 }
 const mockMap = {
     getMapGL: () => mockMapGL,
@@ -22,5 +23,20 @@ describe('Layer', () => {
         layer.addTo(mockMap)
         expect(layer.getMap()).toBe(mockMap)
         expect(layer.getMapGL()).toBe(mockMapGL)
+        mockMapGL.getLayer.mockReturnValueOnce(true)
+        expect(layer.isOnMap()).toBe(true)
+        expect(mockMapGL.getLayer).toHaveBeenCalledWith(layer._id)
+    })
+    it('Should add a non-interactive layer', () => {
+        const layer = new Layer()
+        const mockMapLayer = { id: 42 }
+        layer.addTo(mockMap)
+        layer.addLayer(mockMapLayer)
+        expect(layer.getLayers()).toHaveLength(1)
+        expect(layer.getLayers()[0].id).toBe(mockMapLayer.id)
+        expect(layer.hasLayerId(42)).toBe(true)
+        expect(layer.isVisible()).toBe(true)
+        expect(layer.isInteractive()).toBe(false)
+        expect(layer.getInteractiveIds()).toHaveLength(0)
     })
 })


### PR DESCRIPTION
This PR adds support for proportional circles, used to show point facilities in thematic maps. It also includes a fix for hover state, allow a thematic map to have multiple hover layers (one for polygons and one for circles) 