### PR TITLE
feat: synchronize the view of two maps

### DIFF
--- a/src/Map.js
+++ b/src/Map.js
@@ -10,6 +10,7 @@ import Markers from './layers/Markers'
 import Dots from './layers/Dots'
 import ClientCluster from './layers/ClientCluster'
 import EarthEngine from './layers/EarthEngine'
+import { sync, unsync } from './utils/sync'
 
 const layers = {
     tileLayer: TileLayer,
@@ -253,6 +254,16 @@ export class Map extends EventEmitter {
             .setLngLat(coordinates)
             .setHTML(content)
             .addTo(this._mapgl)
+    }
+
+    // Synchronize the view of two maps
+    sync(map) {
+        sync(this.getMapGL(), map.getMapGL())
+    }
+
+    // Remove synchronize between two maps
+    unsync(map) {
+        unsync(this.getMapGL(), map.getMapGL())
     }
 
     _createClickEvent(evt) {

--- a/src/utils/sync.js
+++ b/src/utils/sync.js
@@ -1,0 +1,60 @@
+// Keep track of attached move handlers
+const moveHandlers = {}
+
+// Returns move handlers for one map
+const getMoveHandlers = map => Object.values(moveHandlers[map._mapId] || {})
+
+// Add move handlers for one map
+const addMoveHandlers = map => {
+    getMoveHandlers(map).forEach(handler => map.on('move', handler))
+}
+
+// Remove move handlers for one map
+const removeMoveHandlers = map => {
+    getMoveHandlers(map).forEach(handler => map.off('move', handler))
+}
+
+// Move map B to the position of map A
+const moveToMapPosition = (mapA, mapB) => {
+    // Remove move handlers to avoid infinite loop
+    removeMoveHandlers(mapB)
+
+    mapB.jumpTo({
+        center: mapA.getCenter(),
+        zoom: mapA.getZoom(),
+        bearing: mapA.getBearing(),
+        pitch: mapA.getPitch(),
+    })
+
+    // Attach move handlers again after map movement
+    addMoveHandlers(mapB)
+}
+
+// Synchronize the view of two maps
+export const sync = (mapA, mapB) => {
+    const onMove = () => moveToMapPosition(mapA, mapB)
+
+    // Keep track for attached move handlers
+    moveHandlers[mapA._mapId] = moveHandlers[mapA._mapId] || {}
+    moveHandlers[mapA._mapId][mapB._mapId] = onMove
+
+    mapA.on('move', onMove)
+}
+
+// Remove synchronize between two maps
+export const unsync = (mapA, mapB) => {
+    const mapHandlers = moveHandlers[mapA._mapId]
+
+    if (mapHandlers) {
+        const handler = mapHandlers[mapB._mapId]
+
+        if (handler) {
+            mapA.off(handler)
+            delete mapHandlers[mapB._mapId]
+        }
+
+        if (!Object.keys(mapHandlers).length) {
+            delete moveHandlers[mapA._mapId]
+        }
+    }
+}


### PR DESCRIPTION
This PR will add basic support for map synchronization using Mapbox GL JS. The Map API gets two new methods, "sync" and "unsync", allowing us to (un)synchronize the movements of one map to another. We listen to the move events of the map, and copies map position to the synced maps. 

The same methods are added to the GIS API: https://github.com/dhis2/gis-api/pull/56