### PR TITLE
fix: mock mapbox popup compoent

### DIFF
--- a/src/__tests__/Map.spec.js
+++ b/src/__tests__/Map.spec.js
@@ -7,6 +7,7 @@ jest.mock('mapbox-gl', () => ({
     }),
     Evented: () => {},
     Marker: () => {},
+    Popup: () => {},
     FullscreenControl: () => {},
 }))
 


### PR DESCRIPTION
Avoids: TypeError: Super expression must either be null or a function