### PR TITLE
fix:  hide bing maps logo if download and reset map tilt in navigation control

### DIFF
--- a/src/Map.css
+++ b/src/Map.css
@@ -1,13 +1,3 @@
-.dhis2-map-bing .mapboxgl-ctrl-bottom-left {
-    left: 60px;
-}
-
-.dhis2-map-bing-logo {
-    position: absolute;
-    bottom: 3px;
-    left: 3px;
-}
-
 .dhis2-map-split-view .mapboxgl-ctrl-group {
     position: absolute;
     top: 10px;

--- a/src/controls/Controls.css
+++ b/src/controls/Controls.css
@@ -100,6 +100,10 @@
     bottom: 0;
 }
 
+.dhis2-map-split-view .dhis2-map-bing-logo {
+    display: none;
+}
+
 .dhis2-map-download .mapboxgl-ctrl-zoom-in,
 .dhis2-map-download .mapboxgl-ctrl-zoom-out,
 .dhis2-map-download .mapboxgl-ctrl-compass,

--- a/src/controls/Navigation.js
+++ b/src/controls/Navigation.js
@@ -1,0 +1,14 @@
+import { NavigationControl } from 'mapbox-gl'
+
+const defaultOptions = {
+    visualizePitch: true
+}
+
+// Extended to reset pitch 
+class Navigation extends NavigationControl {
+    constructor(options = {}) {
+        super({...defaultOptions, ...options})
+    }
+}
+
+export default  Navigation

--- a/src/controls/controlTypes.js
+++ b/src/controls/controlTypes.js
@@ -1,4 +1,5 @@
-import { NavigationControl, AttributionControl, ScaleControl } from 'mapbox-gl'
+import { AttributionControl, ScaleControl } from 'mapbox-gl'
+import Navigation from './Navigation'
 import Search from './Search'
 import Measure from './Measure'
 import FitBounds from './FitBounds'
@@ -6,7 +7,7 @@ import Fullscreen from './Fullscreen'
 import './Controls.css'
 
 export default {
-    zoom: NavigationControl,
+    zoom: Navigation,
     attribution: AttributionControl,
     scale: ScaleControl,
     fullscreen: Fullscreen,

--- a/src/layers/BingLayer.css
+++ b/src/layers/BingLayer.css
@@ -1,0 +1,18 @@
+.dhis2-map-bing-logo {
+    position: absolute;
+    bottom: 3px;
+    left: 3px;
+}
+
+.dhis2-map-bing .mapboxgl-ctrl-bottom-left {
+    left: 60px;
+}
+
+/* Bing logo is blocked by CORS policy */
+.dhis2-map-download .dhis2-map-bing-logo  {
+    display: none;
+}
+
+.dhis2-map-download .dhis2-map-bing .mapboxgl-ctrl-bottom-left {
+    left: 0;
+}

--- a/src/layers/BingLayer.js
+++ b/src/layers/BingLayer.js
@@ -1,6 +1,7 @@
 import fetchJsonp from 'fetch-jsonp'
 import Layer from './Layer'
 import { bboxIntersect } from '../utils/geo'
+import './BingLayer.css'
 
 // https://docs.microsoft.com/en-us/bingmaps/rest-services/directly-accessing-the-bing-maps-tiles
 class BingLayer extends Layer {


### PR DESCRIPTION
This PR fixes: 
- Bing Maps logo is hidden from map downloads due to CORS issues. We still show the textual source. Added bing maps styles in a separate file.
- Bing Maps logo is also hidden from split view maps (so it's not repeated x times). 
- Extend navigation control to allow the user to reset both rotation and tilting. 