### PR TITLE
fix: index and ordering for layer groups (DHIS2-8496)

### DIFF
--- a/src/layers/Layer.js
+++ b/src/layers/Layer.js
@@ -82,7 +82,7 @@ class Layer extends Evented {
     createSource() {
         const id = this.getId()
         const features = this.getFeatures()
-        const { buffer, label, labelStyle } = this.options 
+        const { buffer, label, labelStyle } = this.options
 
         this.setSource(id, {
             type: 'geojson',
@@ -97,10 +97,7 @@ class Layer extends Evented {
         }
 
         if (label) {
-            this.setSource(
-                `${id}-label`,
-                labelSource(features, labelStyle)
-            )
+            this.setSource(`${id}-label`, labelSource(features, labelStyle))
         }
     }
 
@@ -220,9 +217,9 @@ class Layer extends Evented {
         return this.options.index || 0
     }
 
-   setOpacity(opacity) {
+    setOpacity(opacity) {
         setLayersOpacity(this.getMapGL(), this.getId(), opacity)
-   }
+    }
 
     getBounds() {
         const features = this.getFeatures()

--- a/src/layers/LayerGroup.js
+++ b/src/layers/LayerGroup.js
@@ -27,7 +27,7 @@ class LayerGroup extends Evented {
     }
 
     removeFrom(map) {
-        this._layers.some(layer => layer.removeFrom(map))
+        this._layers.forEach(layer => layer.removeFrom(map))
         this._layers = []
         this._layerConfigs = []
     }
@@ -42,6 +42,11 @@ class LayerGroup extends Evented {
 
     isInteractive() {
         return this._layers.some(layer => layer.isInteractive())
+    }
+
+    setIndex(index = 0) {
+        this.options.index = index
+        this._layers.forEach(layer => layer.setIndex(index))
     }
 
     getIndex() {


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-8496

The tracked entities layer uses "layer group" as it contains both points, lines and polygons. The layer group didn't have the setIndex method, only the individual layers. 

Error shown in the console:
<img width="534" alt="Screenshot 2020-03-19 at 13 30 33" src="https://user-images.githubusercontent.com/548708/77067844-e6dea680-69e5-11ea-95a1-cff798685ea0.png">

The method is called from the maps app:
https://github.com/dhis2/maps-app/blob/master/src/components/map/Layer.js#L123

This PR adds this method, and calls the same method on each sublayer. 

There are no code changes in Layer.js (only prettifier). 

The PR also includes a fix for the removeFrom(map) method. 

Tracked entities shown above a thematic map:

<img width="1050" alt="Screenshot 2020-03-19 at 12 30 44" src="https://user-images.githubusercontent.com/548708/77063306-c3aff900-69dd-11ea-97ce-70ca820daf1d.png">

Tracked entities shown below a thematic map:

<img width="1051" alt="Screenshot 2020-03-19 at 12 30 56" src="https://user-images.githubusercontent.com/548708/77063320-c874ad00-69dd-11ea-8405-c4b021b30165.png">
