### PR TITLE
fix: trigger cluster update when new cluster tiles are loaded (DHIS2-8498)

### DIFF
--- a/src/layers/ServerCluster.js
+++ b/src/layers/ServerCluster.js
@@ -156,6 +156,9 @@ class ServerCluster extends Cluster {
                 this.tileClusters[tileId] = 'pending'
                 this.options.load(this.getTileParams(tileId), this.onTileLoad)
             }
+
+            // Trigger cluster update
+            this.onMoveEnd()
         }
     }
 

--- a/src/layers/ServerCluster.js
+++ b/src/layers/ServerCluster.js
@@ -190,7 +190,7 @@ class ServerCluster extends Cluster {
     getBounds = () => this.options.bounds
 
     // Returns true if all tiles aligns with the zoom level
-    isTilesUpdated = () => {
+    areTilesUpdated = () => {
         const mapgl = this._map.getMapGL()
         const zoom = Math.floor(mapgl.getZoom())
 
@@ -238,7 +238,7 @@ class ServerCluster extends Cluster {
     }
 
     getVisibleTiles = async () => {
-        while (!this.isTilesUpdated()) {
+        while (!this.areTilesUpdated()) {
             await new Promise(r => setTimeout(r, 100))
         }
 

--- a/src/layers/ServerCluster.js
+++ b/src/layers/ServerCluster.js
@@ -156,14 +156,11 @@ class ServerCluster extends Cluster {
                 this.tileClusters[tileId] = 'pending'
                 this.options.load(this.getTileParams(tileId), this.onTileLoad)
             }
-
-            // Trigger cluster update
-            this.onMoveEnd()
         }
     }
 
-    onMoveEnd = () => {
-        const tiles = this.getVisibleTiles()
+    onMoveEnd = async () => {
+        const tiles = await this.getVisibleTiles()
 
         if (tiles.join('-') !== this.currentTiles.join('-')) {
             this.currentTiles = tiles
@@ -179,16 +176,28 @@ class ServerCluster extends Cluster {
     }
 
     // Keep tile clusters in memory and update map if needed
-    onTileLoad = (tileId, clusters) => {
+    onTileLoad = async (tileId, clusters) => {
         this.tileClusters[tileId] = clusters
 
-        // If tile still visible after loading
-        if (this.isTileVisible(tileId)) {
+        // Check if tile is still visible after loading
+        const visibleTiles = await this.getVisibleTiles()
+
+        if (visibleTiles.includes(tileId)) {
             this.updateClusters([tileId])
         }
     }
 
     getBounds = () => this.options.bounds
+
+    // Returns true if all tiles aligns with the zoom level
+    isTilesUpdated = () => {
+        const mapgl = this._map.getMapGL()
+        const zoom = Math.floor(mapgl.getZoom())
+
+        return this.getSourceCacheTiles().every(
+            ({ tileID }) => tileID.canonical.z === zoom
+        )
+    }
 
     getSourceCacheTiles = () => {
         const mapgl = this._map.getMapGL()
@@ -214,8 +223,6 @@ class ServerCluster extends Cluster {
         }
     }
 
-    isTileVisible = tileId => this.getVisibleTiles().includes(tileId)
-
     // Returms true if geometry is outside bounds
     isOutsideBounds = bounds => ({ geometry }) => {
         const { coordinates } =
@@ -230,10 +237,15 @@ class ServerCluster extends Cluster {
         )
     }
 
-    getVisibleTiles = () =>
-        this.getSourceCacheTiles()
+    getVisibleTiles = async () => {
+        while (!this.isTilesUpdated()) {
+            await new Promise(r => setTimeout(r, 100))
+        }
+
+        return this.getSourceCacheTiles()
             .map(this.getTileId)
             .sort()
+    }
 
     // Returns sorted array of cluster ids
     getClusterIds = clusters =>


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-8498

When the app or user is quickly zooming the map, the cluster tiles are not yet ready to update. The result is that some clusters remains on the map. The issue is fixed by calling the onMoveEnd method every time a cluster tile is changed. 

Screenshot showing the original issue: 
<img width="1222" alt="Screenshot 2020-03-19 at 15 09 20" src="https://user-images.githubusercontent.com/548708/77094449-caa23000-6a0c-11ea-90e8-ba39730ac268.png">

Screen recording showing that the map is properly updated:
![Screen-Recording-2020-03-19-at-17 56 31](https://user-images.githubusercontent.com/548708/77094715-2ff62100-6a0d-11ea-9e1b-6a1cb5c1cb73.gif)

