### PR TITLE
fix: hide label when mouse cursor leaves the map (DHIS2-8515)

### DIFF
--- a/src/Map.js
+++ b/src/Map.js
@@ -61,8 +61,8 @@ export class MapGL extends Evented {
         mapgl.on('click', this.onClick)
         mapgl.on('contextmenu', this.onContextMenu)
 
-        // TODO: Don't add before we have any vector layers
         mapgl.on('mousemove', this.onMouseMove)
+        mapgl.on('mouseout', this.onMouseOut)
 
         this._layers = []
         this._controls = {}
@@ -132,6 +132,7 @@ export class MapGL extends Evented {
         mapgl.off('click', this.onClick)
         mapgl.off('contextmenu', this.onContextMenu)
         mapgl.off('mousemove', this.onMouseMove)
+        mapgl.off('mouseout', this.onMouseOut)
 
         mapgl.remove()
 
@@ -257,6 +258,8 @@ export class MapGL extends Evented {
 
         this._hoverId = featureSourceId
     }
+
+    onMouseOut = () => this.hideLabel()
 
     // Returns the map zoom level
     getZoom() {


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-8515

We support hover labels for various layers, and this fix removes the label if the mouse cursor leaves the map canvas. 

Shows how the map label is "stuck" at the map edge before this fix: 
<img width="873" alt="Screenshot 2020-03-23 at 17 00 09" src="https://user-images.githubusercontent.com/548708/77336440-d0a75200-6d27-11ea-9466-6f4f20186ec8.png">

