### PR TITLE
fix: use parent container for fullscreen map (DHIS2-8524)

### DIFF
--- a/src/controls/Controls.css
+++ b/src/controls/Controls.css
@@ -27,7 +27,7 @@
 .dhis2-map-split-view .mapboxgl-ctrl-compass:not(:disabled):hover,
 .dhis2-map-split-view .mapboxgl-ctrl-fullscreen:not(:disabled):hover,
 .dhis2-map-split-view .mapboxgl-ctrl-shrink:not(:disabled):hover {
-    background-color: rgba(0, 0, 0, 0.05);
+    background-color: #f3f3f3;
 }
 
 .dhis2-map-split-view .mapboxgl-ctrl-zoom-in {

--- a/src/controls/Fullscreen.js
+++ b/src/controls/Fullscreen.js
@@ -9,16 +9,13 @@ class Fullscreen extends FullscreenControl {
     }
 
     onAdd(map) {
-        const { isPlugin, isSplitView } = this.options
+        const { isSplitView } = this.options
 
-        if (isPlugin) {
-            // TODO: This should be done in a cleaner way
-            this._container = map.getContainer().parentNode.parentNode
-        }
+        // Default fullscreen container
+        this._container = map.getContainer().parentNode.parentNode
 
         if (isSplitView) {
-            // TODO: This should be done in a cleaner way
-            this._container = map.getContainer().parentNode.parentNode.parentNode
+            this._container = this._container.parentNode
         }
 
         this._scrollZoomIsDisabled = !map.scrollZoom.isEnabled()


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-8524

Related PR for Maps app: https://github.com/dhis2/maps-app/pull/522

The default behaviour of the fullscreen control is to open the map container in fullscreen. As we also want to include other elements like map title, it's better to use the 2x parent component. This is the same we already use for plugin/dashboard maps, so it simplifies the code. 

<img width="1493" alt="Screenshot 2020-03-25 at 12 42 28" src="https://user-images.githubusercontent.com/548708/77534051-46323000-6e98-11ea-87aa-93d06028f056.png">

Split view maps (which consists of multiple maps still need to move one level up in the DOM hierarchy). 

<img width="1493" alt="Screenshot 2020-03-25 at 12 42 07" src="https://user-images.githubusercontent.com/548708/77534063-4d593e00-6e98-11ea-9115-79e22f1141cc.png">

The PR also includes a style fix for split view map controls which had a transparent hover style which should be solid. 

Before: 
<img width="464" alt="Screenshot 2020-03-25 at 12 44 45" src="https://user-images.githubusercontent.com/548708/77534010-374b7d80-6e98-11ea-9001-8579e243f5d2.png">

After: 
<img width="463" alt="Screenshot 2020-03-25 at 12 48 46" src="https://user-images.githubusercontent.com/548708/77533990-2e5aac00-6e98-11ea-9094-e98bdcd6ec76.png">


