### PR TITLE
fix: resize map when toggling fullscreen view (DHIS2-8702)

### DIFF
--- a/src/controls/Controls.css
+++ b/src/controls/Controls.css
@@ -27,7 +27,7 @@
 .dhis2-map-split-view .mapboxgl-ctrl-compass:not(:disabled):hover,
 .dhis2-map-split-view .mapboxgl-ctrl-fullscreen:not(:disabled):hover,
 .dhis2-map-split-view .mapboxgl-ctrl-shrink:not(:disabled):hover {
-    background-color: rgba(0, 0, 0, 0.05);
+    background-color: #f3f3f3;
 }
 
 .dhis2-map-split-view .mapboxgl-ctrl-zoom-in {

--- a/src/controls/Fullscreen.js
+++ b/src/controls/Fullscreen.js
@@ -9,16 +9,13 @@ class Fullscreen extends FullscreenControl {
     }
 
     onAdd(map) {
-        const { isPlugin, isSplitView } = this.options
+        const { isSplitView } = this.options
 
-        if (isPlugin) {
-            // TODO: This should be done in a cleaner way
-            this._container = map.getContainer().parentNode.parentNode
-        }
+        // Default fullscreen container
+        this._container = map.getContainer().parentNode.parentNode
 
         if (isSplitView) {
-            // TODO: This should be done in a cleaner way
-            this._container = map.getContainer().parentNode.parentNode.parentNode
+            this._container = this._container.parentNode
         }
 
         this._scrollZoomIsDisabled = !map.scrollZoom.isEnabled()

--- a/src/controls/Fullscreen.js
+++ b/src/controls/Fullscreen.js
@@ -31,6 +31,11 @@ class Fullscreen extends FullscreenControl {
 
         super._onClickFullscreen()
     }
+
+    _changeIcon() {
+        this._map.resize()
+        super._changeIcon()
+    }
 }
 
 export default Fullscreen


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-8702

This small PR fixes an issue when the map is opened in fullscreen in a browser which is already in fullscreen mode. This fix is to run the resize method on the map by overriding the _changeIcon method which is called _after_ the fullscreen mode has changed. 

Before this fix: 
<img width="1440" alt="Screenshot 2020-04-23 at 12 36 16" src="https://user-images.githubusercontent.com/548708/80091504-7c2f0680-8561-11ea-957b-a04d8aca8a13.png">

After this fix: 
<img width="1440" alt="Screenshot 2020-04-23 at 12 38 09" src="https://user-images.githubusercontent.com/548708/80091518-818c5100-8561-11ea-9f61-637eb5090958.png">
