### PR TITLE
feat: color option for choropleth layers (DHIS2-8642)

### DIFF
--- a/src/layers/Choropleth.js
+++ b/src/layers/Choropleth.js
@@ -12,11 +12,11 @@ class Choropleth extends Layer {
 
     createLayers() {
         const id = this.getId()
-        const { label, labelStyle, noDataColor } = this.options
+        const { label, labelStyle, color } = this.options
 
-        this.addLayer(polygonLayer({ id, color: noDataColor }), true)
+        this.addLayer(polygonLayer({ id, color }), true)
         this.addLayer(outlineLayer({ id }))
-        this.addLayer(pointLayer({ id, color: noDataColor }), true)
+        this.addLayer(pointLayer({ id, color }), true)
 
         if (label) {
             this.addLayer(labelLayer({ id, label, ...labelStyle }))

--- a/src/layers/Choropleth.js
+++ b/src/layers/Choropleth.js
@@ -12,7 +12,7 @@ class Choropleth extends Layer {
 
     createLayers() {
         const id = this.getId()
-        const { label, labelStyle, color } = this.options
+        const { color, label, labelStyle } = this.options
 
         this.addLayer(polygonLayer({ id, color }), true)
         this.addLayer(outlineLayer({ id }))

--- a/src/layers/Choropleth.js
+++ b/src/layers/Choropleth.js
@@ -12,11 +12,11 @@ class Choropleth extends Layer {
 
     createLayers() {
         const id = this.getId()
-        const { label, labelStyle } = this.options
-        
-        this.addLayer(polygonLayer({ id }), true)
+        const { label, labelStyle, noDataColor } = this.options
+
+        this.addLayer(polygonLayer({ id, color: noDataColor }), true)
         this.addLayer(outlineLayer({ id }))
-        this.addLayer(pointLayer({ id }), true)
+        this.addLayer(pointLayer({ id, color: noDataColor }), true)
 
         if (label) {
             this.addLayer(labelLayer({ id, label, ...labelStyle }))

--- a/src/layers/Layer.js
+++ b/src/layers/Layer.js
@@ -255,7 +255,7 @@ class Layer extends Evented {
             const { properties } = feature
             const content = (hoverLabel || label).replace(
                 /\{ *([\w_-]+) *\}/g,
-                (str, key) => properties[key]
+                (str, key) => properties[key] || ''
             )
             const { lngLat, point } = evt
 


### PR DESCRIPTION
Partly fixes: https://jira.dhis2.org/browse/DHIS2-8642

This PR allows a color value to be passed in as a layer option for choropleths. If there is no color value present for the feature, the fallback will be to this value. It can be used to define a "no data color". 

It also includes a fix for hover labels: If there is no value present for the template provided, we'll show an empty string and not "undefined". 