### PR TITLE
feat: scroll zoom toggle

### DIFF
--- a/src/Map.js
+++ b/src/Map.js
@@ -74,7 +74,7 @@ export class MapGL extends Evented {
     fitBounds(bounds) {
         if (bounds) {
             this._mapgl.fitBounds(bounds, {
-                padding: 20,
+                padding: 10,
                 duration: 0,
             })
         }
@@ -358,6 +358,10 @@ export class MapGL extends Evented {
         if (this._label) {
             this._label.remove()
         }
+    }
+
+    toggleScrollZoom(isEnabled) {
+        this.getMapGL().scrollZoom[isEnabled ? 'enable' : 'disable']()
     }
 
     // Only called within the API

--- a/src/controls/Fullscreen.js
+++ b/src/controls/Fullscreen.js
@@ -40,6 +40,4 @@ class Fullscreen extends FullscreenControl {
     }
 }
 
-
-
 export default Fullscreen

--- a/src/controls/Fullscreen.js
+++ b/src/controls/Fullscreen.js
@@ -8,6 +8,13 @@ class Fullscreen extends FullscreenControl {
         this.options = options
     }
 
+    addTo(map) {
+        this._eventMap = map;
+        this._map = map.getMapGL()
+
+        this._map.addControl(this)
+    }
+
     onAdd(map) {
         const { isSplitView } = this.options
 
@@ -18,16 +25,11 @@ class Fullscreen extends FullscreenControl {
             this._container = this._container.parentNode
         }
 
-        this._scrollZoomIsDisabled = !map.scrollZoom.isEnabled()
-
         return super.onAdd(map)
     }
 
     _onClickFullscreen() {
-        // Always enable scroll zoom in fullscreen
-        if (this._scrollZoomIsDisabled) {
-            this._map.scrollZoom[this._isFullscreen() ? 'disable' : 'enable']()
-        }
+        this._eventMap.fire('fullscreenchange', { isFullscreen: !this._isFullscreen() });
 
         super._onClickFullscreen()
     }
@@ -37,5 +39,7 @@ class Fullscreen extends FullscreenControl {
         super._changeIcon()
     }
 }
+
+
 
 export default Fullscreen


### PR DESCRIPTION
This PR adds a toggleScrollZoom method to the map class. It will be used to enable scroll zoom when in fullscreen mode. 

Fixes the maps-gl part for: https://jira.dhis2.org/browse/DHIS2-9426

The scroll zoom toggle is removed from the fullscreen control, and will be toggled from the maps app. 