### PR TITLE
fix: ee api upgrade

### DIFF
--- a/src/utils/eeapi.js
+++ b/src/utils/eeapi.js
@@ -1,7 +1,7 @@
 // import ee from '@google/earthengine' // Run "yarn add @google/earthengine"
 
 // Load EE API in demand
-const apiVersion = 'v0.1.226'
+const apiVersion = 'v0.1.235'
 const scriptUrl = `https://cdn.rawgit.com/google/earthengine-api/${apiVersion}/javascript/build/ee_api_js.js`
 
 // Returns the Earth Engine API as a promise


### PR DESCRIPTION
"We are in the process of transitioning to new and improved Earth Engine servers, which may require that you update your client libraries.  If you are using an old Earth Engine client, you will receive an error like "Unexpected HTTP error: Earth Engine servers now require client library v0.1.232, released August 19.  Please update to the latest Python or JavaScript version to avoid a break in service." - The Google Earth Engine team