### PR TITLE
fix: pass map click event back to app (DHIS2-10071)

### DIFF
--- a/src/Map.js
+++ b/src/Map.js
@@ -200,6 +200,8 @@ export class MapGL extends Evented {
                 layer.onClick(eventObj)
             }
         }
+
+        this.fire('click', eventObj)
     }
 
     onContextMenu = evt => {


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-10071

As we have created a wrapper around the mapbox-gl map instance, we need to pass on the click event in case the app is listening. We use the click event in the DHIS2 Maps to close the right-click context menu. 