### PR TITLE
fix: multitouch for map panning (DHIS2-10252)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "fetch-jsonp": "^1.1.3",
     "lodash.throttle": "^4.1.1",
     "mapbox-gl": "^1.11.0",
+    "mapbox-gl-multitouch": "^1.0.3",
     "mapboxgl-spiderifier": "^1.0.9",
     "polylabel": "^1.1.0",
     "suggestions": "^1.7.0",

--- a/src/Map.js
+++ b/src/Map.js
@@ -1,6 +1,6 @@
-import { Map } from 'mapbox-gl'
+import { Evented, Map } from 'mapbox-gl'
 import 'mapbox-gl/dist/mapbox-gl.css'
-import { Evented } from 'mapbox-gl'
+import MultiTouch from 'mapbox-gl-multitouch'
 import Layer from './layers/Layer'
 import layerTypes from './layers/layerTypes'
 import controlTypes from './controls/controlTypes'
@@ -44,6 +44,10 @@ export class MapGL extends Evented {
             transformRequest,
             ...opts,
         })
+
+        // Added to allow dashboards to be scrolled on touch devices
+        // Map can be panned with two fingers instead of one
+        mapgl.addControl(new MultiTouch())
 
         this._mapgl = mapgl
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4590,6 +4590,11 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+mapbox-gl-multitouch@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/mapbox-gl-multitouch/-/mapbox-gl-multitouch-1.0.3.tgz#db8bbe86a15d8398e3315d97305c9edde3f0f0d7"
+  integrity sha512-lpTFL2Sp7hK867mkMOZe2DvdS5eEHxWfMc7aSWCRDMgSq9IjPubsiix3FPs+IqcbkYmR+IUrzvH9RWBOXVs2cg==
+
 mapbox-gl@^1.11.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/mapbox-gl/-/mapbox-gl-1.11.0.tgz#7056d7cc1693e157eb5c2beb1476d620670d65e9"


### PR DESCRIPTION
Partly fixes: https://jira.dhis2.org/browse/DHIS2-10252

Switch to multitouch for map panning to avoid "scroll trap" on dashboards. 
