### PR TITLE
feat: circle buffer aggregations for EE layers (DHIS2-10549)

### DIFF
--- a/src/Map.css
+++ b/src/Map.css
@@ -9,6 +9,14 @@
     right: 10px;
 }
 
+.dhis2-map-popup {
+    z-index: 20;
+}
+
+.dhis2-map-popup .mapboxgl-popup-close-button:focus {
+    outline: none;
+}
+
 .dhis2-map-popup .mapboxgl-popup-content {
     box-shadow: 0 3px 14px rgba(0, 0, 0, 0.4);
 }

--- a/src/layers/EarthEngine.js
+++ b/src/layers/EarthEngine.js
@@ -158,7 +158,7 @@ class EarthEngine extends Layer {
         }
     }
 
-    // Create buffer polygon around point feature
+    // Transform point feature to buffer polygon
     createBuffer(feature) {
         const { buffer } = this.options
 

--- a/src/layers/EarthEngine.js
+++ b/src/layers/EarthEngine.js
@@ -145,17 +145,12 @@ class EarthEngine extends Layer {
     }
 
     setFeatures(data = []) {
-        const points = data.filter(isPoint)
+        this.setSource(`${this.getId()}-points`, {
+            type: 'geojson',
+            data: featureCollection(data.filter(isPoint)),
+        })
 
-        if (points.length) {
-            this.setSource(`${this.getId()}-points`, {
-                type: 'geojson',
-                data: featureCollection(points),
-            })
-            super.setFeatures(data.map(this.createBuffer.bind(this)))
-        } else {
-            super.setFeatures(data)
-        }
+        super.setFeatures(data.map(this.createBuffer.bind(this)))
     }
 
     // Transform point feature to buffer polygon

--- a/src/layers/Events.js
+++ b/src/layers/Events.js
@@ -20,7 +20,10 @@ class Events extends Layer {
             this.addLayer(bufferOutlineLayer({ id, ...bufferStyle }))
         }
 
-        this.addLayer(pointLayer({ id, color, radius, strokeColor: eventStrokeColor }), true)
+        this.addLayer(
+            pointLayer({ id, color, radius, strokeColor: eventStrokeColor }),
+            true
+        )
         this.addLayer(polygonLayer({ id, color }), true)
         this.addLayer(outlineLayer({ id, color: eventStrokeColor }))
     }

--- a/src/layers/Layer.js
+++ b/src/layers/Layer.js
@@ -174,10 +174,6 @@ class Layer extends Evented {
         return this.getLayers().some(layer => layer.id === id)
     }
 
-    hasSourceId(id) {
-        return !!this._source[id]
-    }
-
     moveToTop() {
         const mapgl = this.getMapGL()
 

--- a/src/layers/Layer.js
+++ b/src/layers/Layer.js
@@ -174,6 +174,10 @@ class Layer extends Evented {
         return this.getLayers().some(layer => layer.id === id)
     }
 
+    hasSourceId(id) {
+        return !!this._source[id]
+    }
+
     moveToTop() {
         const mapgl = this.getMapGL()
 

--- a/src/utils/__tests__/geometry.spec.js
+++ b/src/utils/__tests__/geometry.spec.js
@@ -1,0 +1,32 @@
+import { isPoint } from '../geometry'
+
+const point = {
+    type: 'Feature',
+    geometry: {
+        type: 'Point',
+        coordinates: [125.6, 10.1],
+    },
+}
+
+const polygon = {
+    type: 'Feature',
+    geometry: {
+        type: 'Polygon',
+        coordinates: [
+            [
+                [100.0, 0.0],
+                [101.0, 0.0],
+                [101.0, 1.0],
+                [100.0, 1.0],
+                [100.0, 0.0],
+            ],
+        ],
+    },
+}
+
+describe('numbers', () => {
+    it('Should return true if a feature has point geometry', () => {
+        expect(isPoint(point)).toBe(true)
+        expect(isPoint(polygon)).toBe(false)
+    })
+})

--- a/src/utils/buffers.js
+++ b/src/utils/buffers.js
@@ -8,16 +8,22 @@ const defaults = {
     width: 1,
 }
 
-const getBufferGeometry = ({ geometry }, buffer) => 
-    (geometry.type === 'Point' ? circle(geometry, buffer) : polygonBuffer(geometry, buffer)).geometry
+// Buffer in km
+export const getBufferGeometry = ({ geometry }, buffer) =>
+    (geometry.type === 'Point'
+        ? circle(geometry, buffer)
+        : polygonBuffer(geometry, buffer)
+    ).geometry
 
 // Buffer in km
 export const bufferSource = (features, buffer) => ({
     type: 'geojson',
-    data: featureCollection(features.map(feature => ({
-        ...feature,
-        geometry: getBufferGeometry(feature, buffer)
-    }))),
+    data: featureCollection(
+        features.map(feature => ({
+            ...feature,
+            geometry: getBufferGeometry(feature, buffer),
+        }))
+    ),
 })
 
 // Layer with buffer features
@@ -37,6 +43,6 @@ export const bufferOutlineLayer = ({ id, color, width }) => ({
     source: `${id}-buffer`,
     paint: {
         'line-color': colorExpr(color || defaults.color),
-        'line-width': width || defaults.width,
+        'line-width': width || defaults.width,
     },
 })

--- a/src/utils/geometry.js
+++ b/src/utils/geometry.js
@@ -1,5 +1,7 @@
 import { LngLatBounds } from 'mapbox-gl'
 
+export const isPoint = feature => feature.geometry.type === 'Point'
+
 export const getBoundsFromLayers = (layers = []) => {
     const bounds = layers.reduce((b, l) => {
         if (l.getBounds) {

--- a/src/utils/style.js
+++ b/src/utils/style.js
@@ -4,14 +4,22 @@ export const textColor = '#FFFFFF'
 
 export const radius = 6
 
-export const noDataColor ='#CCCCCC'
+export const noDataColor = '#CCCCCC'
 
 export const strokeColor = '#333333'
 export const strokeWidth = 1
-export const hoverStrokeWidth = 3
+export const hoverStrokeWidth = 4
 
-export const eventStrokeColor = '#FFFFFF'
+export const eventStrokeColor = '#333333'
 
 export default {
-    textFont, textSize, textColor, radius, noDataColor, strokeColor, strokeWidth, hoverStrokeWidth, eventStrokeColor
+    textFont,
+    textSize,
+    textColor,
+    radius,
+    noDataColor,
+    strokeColor,
+    strokeWidth,
+    hoverStrokeWidth,
+    eventStrokeColor,
 }


### PR DESCRIPTION
Partly fixes: https://jira.dhis2.org/browse/DHIS2-10549

Related maps-app PR: https://github.com/dhis2/maps-app/pull/1504

This PR use the buffer option for EE layers to create circle polygons for each point feature. All polygon features will then be used for aggregations. Both the circle polygon and a dot for the point feature will be displayed on the map. 

<img width="1004" alt="Screenshot 2021-02-22 at 17 07 27" src="https://user-images.githubusercontent.com/548708/108737425-e2ded100-7532-11eb-9540-61a5c396e8ad.png">

The style for feature hover/highlight was adjusted - thicker lines and black outline for events. 

This PR also includes to small style fixes: 

Outline for close 'x' in popups is removed:
<img width="281" alt="Screenshot 2021-02-22 at 16 12 15" src="https://user-images.githubusercontent.com/548708/108737242-b3c85f80-7532-11eb-8177-90e201d2805f.png">

Popup is placed above map controls: 
<img width="201" alt="Screenshot 2021-02-22 at 16 22 43" src="https://user-images.githubusercontent.com/548708/108737482-eeca9300-7532-11eb-8541-85b9789e5862.png">


