### PR TITLE
feat: improve multitouch handling (DHIS2-10413)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "fetch-jsonp": "^1.1.3",
     "lodash.throttle": "^4.1.1",
     "mapbox-gl": "^1.11.0",
-    "mapbox-gl-multitouch": "^1.0.3",
     "mapboxgl-spiderifier": "^1.0.9",
     "polylabel": "^1.1.0",
     "suggestions": "^1.7.0",

--- a/src/Map.js
+++ b/src/Map.js
@@ -390,7 +390,7 @@ export class MapGL extends Evented {
         if (isEnabled && !hasControl) {
             mapgl.addControl(this._multiTouch)
         } else if (!isEnabled && hasControl) {
-            mapgl.addControl(this._multiTouch)
+            mapgl.removeControl(this._multiTouch)
         }
     }
 

--- a/src/Map.js
+++ b/src/Map.js
@@ -1,10 +1,10 @@
 import { Evented, Map } from 'mapbox-gl'
 import 'mapbox-gl/dist/mapbox-gl.css'
-import MultiTouch from 'mapbox-gl-multitouch'
 import Layer from './layers/Layer'
 import layerTypes from './layers/layerTypes'
 import controlTypes from './controls/controlTypes'
 import controlsLocale from './controls/controlsLocale'
+import MultiTouch from './controls/MultiTouch'
 import { transformRequest } from './utils/images'
 import { getBoundsFromLayers } from './utils/geometry'
 import syncMaps from './utils/sync'
@@ -69,10 +69,6 @@ export class MapGL extends Evented {
         if (options.attributionControl !== false) {
             this.addControl({ type: 'attribution' })
         }
-
-        // Added to allow dashboards to be scrolled on touch devices
-        // Map can be panned with two fingers instead of one
-        mapgl.addControl(new MultiTouch())
     }
 
     fitBounds(bounds) {
@@ -368,6 +364,24 @@ export class MapGL extends Evented {
 
     toggleScrollZoom(isEnabled) {
         this.getMapGL().scrollZoom[isEnabled ? 'enable' : 'disable']()
+    }
+
+    // Added to allow dashboards to be scrolled on touch devices
+    // Map can be panned with two fingers instead of one
+    toggleMultiTouch(isEnabled) {
+        const mapgl = this.getMapGL()
+
+        if (this._multiTouch) {
+            this._multiTouch = new MultiTouch()
+        }
+
+        const hasControl = mapgl.hasControl(this._multiTouch)
+
+        if (isEnabled && !hasControl) {
+            mapgl.addControl(this._multiTouch)
+        } else if (!isEnabled && hasControl) {
+            mapgl.addControl(this._multiTouch)
+        }
     }
 
     // Only called within the API

--- a/src/Map.js
+++ b/src/Map.js
@@ -381,7 +381,7 @@ export class MapGL extends Evented {
     toggleMultiTouch(isEnabled) {
         const mapgl = this.getMapGL()
 
-        if (this._multiTouch) {
+        if (!this._multiTouch) {
             this._multiTouch = new MultiTouch()
         }
 

--- a/src/controls/Fullscreen.js
+++ b/src/controls/Fullscreen.js
@@ -30,8 +30,7 @@ class Fullscreen extends FullscreenControl {
 
     _onClickFullscreen() {
         this._eventMap.fire('fullscreenchange', {
-            scrollZoom: this._isFullscreen(),
-            fitBounds: !this._isFullscreen(),
+            isFullscreen: !this._isFullscreen(),
         })
 
         super._onClickFullscreen()

--- a/src/controls/Fullscreen.js
+++ b/src/controls/Fullscreen.js
@@ -31,6 +31,7 @@ class Fullscreen extends FullscreenControl {
     _onClickFullscreen() {
         this._eventMap.fire('fullscreenchange', {
             scrollZoom: this._isFullscreen(),
+            fitBounds: !this._isFullscreen(),
         })
 
         super._onClickFullscreen()

--- a/src/controls/Fullscreen.js
+++ b/src/controls/Fullscreen.js
@@ -9,7 +9,7 @@ class Fullscreen extends FullscreenControl {
     }
 
     addTo(map) {
-        this._eventMap = map;
+        this._eventMap = map
         this._map = map.getMapGL()
 
         this._map.addControl(this)
@@ -29,7 +29,9 @@ class Fullscreen extends FullscreenControl {
     }
 
     _onClickFullscreen() {
-        this._eventMap.fire('fullscreenchange', { isFullscreen: !this._isFullscreen() });
+        this._eventMap.fire('fullscreenchange', {
+            scrollZoom: this._isFullscreen(),
+        })
 
         super._onClickFullscreen()
     }

--- a/src/controls/MultiTouch.js
+++ b/src/controls/MultiTouch.js
@@ -60,7 +60,7 @@ class MultiTouch {
 
     onAdd(map) {
         this.map = map
-        this.container = document.createElement('div')
+        this._container = document.createElement('div')
 
         const container = map.getContainer()
 
@@ -71,7 +71,7 @@ class MultiTouch {
             map.dragPan.disable()
         }
 
-        return this.container
+        return this._container
     }
 
     onRemove() {

--- a/src/controls/MultiTouch.js
+++ b/src/controls/MultiTouch.js
@@ -1,0 +1,91 @@
+// Based on https://github.com/Pitbi/mapbox-gl-multitouch (no longer maintained)
+class MultiTouch {
+    constructor() {
+        this.state = {
+            panStart: { x: 0, y: 0 },
+            scale: 1,
+        }
+        this.touchStart = this.touchStart.bind(this)
+        this.touchMove = this.touchMove.bind(this)
+    }
+
+    touchStart(event) {
+        if (event.touches.length !== 2) {
+            return
+        }
+
+        event.stopImmediatePropagation()
+        event.preventDefault()
+
+        let x = 0
+        let y = 0
+
+        ;[].forEach.call(event.touches, touch => {
+            x += touch.screenX
+            y += touch.screenY
+        })
+
+        this.state.panStart.x = x / event.touches.length
+        this.state.panStart.y = y / event.touches.length
+    }
+
+    touchMove(event) {
+        if (event.touches.length !== 2) {
+            return
+        }
+
+        if (this.state.scale === event.scale) {
+            event.stopImmediatePropagation()
+            event.preventDefault()
+        }
+
+        this.state.scale = event.scale
+
+        let x = 0
+        let y = 0
+
+        ;[].forEach.call(event.touches, touch => {
+            x += touch.screenX
+            y += touch.screenY
+        })
+
+        const movex = x / event.touches.length - this.state.panStart.x
+        const movey = y / event.touches.length - this.state.panStart.y
+
+        this.state.panStart.x = x / event.touches.length
+        this.state.panStart.y = y / event.touches.length
+
+        this.map.panBy([movex / -1, movey / -1], { animate: false })
+    }
+
+    onAdd(map) {
+        this.map = map
+        this.container = document.createElement('div')
+
+        const container = map.getContainer()
+
+        container.addEventListener('touchstart', this.touchStart, false)
+        container.addEventListener('touchmove', this.touchMove, false)
+
+        if ('ontouchstart' in document.documentElement) {
+            map.dragPan.disable()
+        }
+
+        return this.container
+    }
+
+    onRemove() {
+        const container = this.map.getContainer()
+
+        container.removeEventListener('touchstart', this.touchStart)
+        container.removeEventListener('touchmove', this.touchMove)
+
+        if ('ontouchstart' in document.documentElement) {
+            this.map.dragPan.enable()
+        }
+
+        this.map = undefined
+    }
+}
+
+export default MultiTouch

--- a/yarn.lock
+++ b/yarn.lock
@@ -4590,11 +4590,6 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-mapbox-gl-multitouch@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/mapbox-gl-multitouch/-/mapbox-gl-multitouch-1.0.3.tgz#db8bbe86a15d8398e3315d97305c9edde3f0f0d7"
-  integrity sha512-lpTFL2Sp7hK867mkMOZe2DvdS5eEHxWfMc7aSWCRDMgSq9IjPubsiix3FPs+IqcbkYmR+IUrzvH9RWBOXVs2cg==
-
 mapbox-gl@^1.11.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/mapbox-gl/-/mapbox-gl-1.11.0.tgz#7056d7cc1693e157eb5c2beb1476d620670d65e9"


### PR DESCRIPTION
Partly fixes: https://jira.dhis2.org/browse/DHIS2-10413

The mapbox-gl-multitouch dependency we used has been deprecated by the author (https://www.npmjs.com/package/mapbox-gl-multitouch), so I copied the code into the repo and made some smaller adjustments. 

We use multitouch as an alternative to one finger panning on dashboard maps, to avoid a "page scroll trap". We're no longer enabling multitouch by default - it kan be turned on and off with the new `toggleMultiTouch(isEnabled)` method. This allows us to disable one finger panning for dashboard maps, but enable it in fullscreen mode. 