### PR TITLE
fix: only add vector layers if needed (DHIS2-10604)

### DIFF
--- a/src/layers/EarthEngine.js
+++ b/src/layers/EarthEngine.js
@@ -57,10 +57,12 @@ class EarthEngine extends Layer {
             tiles: [urlFormat],
         })
 
-        this.setSource(id, {
-            type: 'geojson',
-            data: featureCollection(this.getFeatures()),
-        })
+        if (this.options.data) {
+            this.setSource(id, {
+                type: 'geojson',
+                data: featureCollection(this.getFeatures()),
+            })
+        }
     }
 
     createLayers() {
@@ -73,16 +75,18 @@ class EarthEngine extends Layer {
             source: `${id}-raster`,
         })
 
-        this.addLayer(polygonLayer({ id, source, opacity: 0.9 }), true)
-        this.addLayer(outlineLayer({ id, source }))
-        this.addLayer(
-            pointLayer({
-                id,
-                source: `${id}-points`,
-                radius: 4,
-                color: '#333',
-            })
-        )
+        if (this.options.data) {
+            this.addLayer(polygonLayer({ id, source, opacity: 0.9 }), true)
+            this.addLayer(outlineLayer({ id, source }))
+            this.addLayer(
+                pointLayer({
+                    id,
+                    source: `${id}-points`,
+                    radius: 4,
+                    color: '#333',
+                })
+            )
+        }
     }
 
     // Configures client-side authentication of EE API calls by providing a OAuth2 token to use.

--- a/src/layers/__tests__/EarthEngine.spec.js
+++ b/src/layers/__tests__/EarthEngine.spec.js
@@ -204,6 +204,13 @@ describe('EarthEngine', () => {
         expect(layer4.source).toBe(`${id}-points`)
     })
 
+    it('Should not create geojson layers if feature data is missing', async () => {
+        const layer = new EarthEngine({ ...options, data: null })
+        await layer.addTo(mockMap)
+
+        expect(layer.getLayers().length).toBe(1)
+    })
+
     it('Should call onLoad option when loaded', async () => {
         const layer = new EarthEngine(options)
         const numCalls = onLoad.mock.calls.length


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-10604

This PR will add an extra check and only create vector layers if feature data (org units) are available. 