### PR TITLE
chore: improved styles in measurement dialog

### DIFF
--- a/src/controls/Measure.css
+++ b/src/controls/Measure.css
@@ -73,7 +73,7 @@
 .dhis2-map-ctrl-measure-center {
     color: #212934; /* grey900 */
     padding-right: 20px;
-    background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMCAYAAABWdVznAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAOhJREFUKJGVkTFug0AQRd+sgBOkyT1MvxVdipQpbDcBrsExAq4iipQWpbvt1xeJlBNgsZPCYK1sJ1GmfX//PM3CP0cAXqrjQwqVqmbG4N7b3AFsa29DwIrIeILuo1t9GYAUKqD4pbiYMyQAqpoBrt/lTZyaN7l16RsguzwwBreENq/HZ0TfEFEVrfs2H2Iu17s3pf/E8CSTmCDs+93qMebm9gyiMomZJNyyRWlbe7s4q2itInvBgFJe8wQgBOxc4Po2H4Ahbo15craQESjWpW9++AeLcrgonaBLzw3ZPW+UQxrG9i77a74B+z5bQloZOFAAAAAASUVORK5CYII=);
+    background-image: url("data:image/svg+xml;utf8,<svg width='16' height='16' viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'><path d='m3 10v3h3v1h-3c-.55228475 0-1-.4477153-1-1v-3zm11 0v3c0 .5522847-.4477153 1-1 1h-3v-1h3v-3zm-4-5c.5522847 0 1 .44771525 1 1v4c0 .5522847-.4477153 1-1 1h-4c-.55228475 0-1-.4477153-1-1v-4c0-.55228475.44771525-1 1-1zm0 1h-4v4h4zm3-4c.5522847 0 1 .44771525 1 1v3h-1v-3h-3v-1zm-7 0v1h-3v3h-1v-3c0-.55228475.44771525-1 1-1z' fill='%23212934'/></svg>");
 }
 
 .dhis2-map-ctrl-measure-delete {

--- a/src/controls/Measure.css
+++ b/src/controls/Measure.css
@@ -61,21 +61,24 @@
 }
 
 .dhis2-map-ctrl-measure-cancel {
+    color: #4a5768; /* grey700 */
     padding-right: 20px;
-    background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMCAYAAABWdVznAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAS9JREFUKJGFkDFOAlEURc8dRphJFNmBHYnQYbTHDnsa0BDBRq1YC4naIQbWYEloqKQyswIXQEgwDIn5z2IATUR95X/nvpz7xWqq7XEYztO3QM2wAoCkyLCBt5zf9XrlGEAAtebkwPfdM+iQLWMQpVKu8nh/8qZqexyG7zuT3+DvoVwme+QlGmtYTcMGG8h4MnOtlUpxFs9ufKD2BbjTULqMwZlhobhaoO5mL+q+YQUlVZB0HoMF0EKwwLpC9XVApoL3w9UwgOk00LYuvqQIKK2dEw3rBrmFhSR6wMXqXOQbNhAqJQ9utECJhiAGc7KRZ1oF1FejMQxcZu9FUPznW19zmeyx1+uV41TKVQyiv2DnPs46nfxyU6zRGAaW3r02UZepsHYG9feD7EOnk18CfAKwIX1qvqPBeQAAAABJRU5ErkJggg==);
 }
 
 .dhis2-map-ctrl-measure-finish {
-    background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMCAYAAABWdVznAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAOxAAADsQBlSsOGwAAASVJREFUKJF1kDFLAgEYhp/37tQ7KPMftAnZZtjSkg2B7S5KHLRVk3O/IQiEakzQra2h0SannOR+QWuLYKF03teQwkHeO3483/e+7ydWanZGQTDLXwMtwyoAkiLDBs5idt/r1ecAAmhdjHc9L3kF7bFBBpHrJo2nh8MPNTujIPjKjbPg9FKpUDxw/mJkw2Y8G3wL9qfz6ZUDtLLP2l0gQiACMNF21gVX+kzDvnQzx14ENQCZKk7K+s39cSoGkzQMOkmbepIioCpxHOeW57l4ceR5/nITDBZ5hg2EqgBCt7FXyMXY6X8YQH2F4dBPCtvvgv3M8oDBpFQo1pxerz533aRhq09kwUkSn3W75YXWwzAc+pbfujTRlqmyzgzq7/jFx263vAD4BStdctyYQ7zEAAAAAElFTkSuQmCC);
+    color: #1565c0; /* blue700 */
+    background-image: url("data:image/svg+xml;utf8,<svg width='16' height='16' viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'><path d='m13.6464466 3.64644661c.1952622-.19526215.5118446-.19526215.7071068 0 .1735663.17356635.1928515.44299075.0578554.63785889l-.0578554.06924789-8.00000001 8.00000001c-.17356635.1735663-.44299075.1928515-.63785889.0578554l-.06924789-.0578554-3-3.00000001c-.19526215-.19526215-.19526215-.51184463 0-.70710678.17356635-.17356635.44299075-.1928515.63785889-.05785545l.06924789.05785545 2.64644661 2.64655339z' fill='%231565c0'/></svg>");
 }
 
 .dhis2-map-ctrl-measure-center {
+    color: #212934; /* grey900 */
     padding-right: 20px;
     background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMCAYAAABWdVznAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAOhJREFUKJGVkTFug0AQRd+sgBOkyT1MvxVdipQpbDcBrsExAq4iipQWpbvt1xeJlBNgsZPCYK1sJ1GmfX//PM3CP0cAXqrjQwqVqmbG4N7b3AFsa29DwIrIeILuo1t9GYAUKqD4pbiYMyQAqpoBrt/lTZyaN7l16RsguzwwBreENq/HZ0TfEFEVrfs2H2Iu17s3pf/E8CSTmCDs+93qMebm9gyiMomZJNyyRWlbe7s4q2itInvBgFJe8wQgBOxc4Po2H4Ahbo15craQESjWpW9++AeLcrgonaBLzw3ZPW+UQxrG9i77a74B+z5bQloZOFAAAAAASUVORK5CYII=);
 }
 
 .dhis2-map-ctrl-measure-delete {
-    background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAMCAYAAAC0qUeeAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEwAACxMBAJqcGAAAALlJREFUKJFjZEACcWmn5zMwMCbA+P///ZuzeI5ZKozPaF+/n4WBgYFB7gmfKiPj30PfeP/Irem3+h5SeIyT4yvLQxZGFuv7Eh/vMzAwMDDGpJz6wcTExM5AEPz7BbX+zH98ymDyTMiCsamnq7HRMICimJGRsQUbjVUxIUAvxf8ZqrDSSCoY49JO/UtLO8OFzbSkpCO8cSlnfjMwMDCwMDAw/mdgOD3nBwPDp7i0MxiK/0BsmMbAwMAAACl8PxDSJvyvAAAAAElFTkSuQmCC);
+    color: #c62828; /* red700 */
+    background-image: url("data:image/svg+xml;utf8,<svg width='16' height='16' viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'><path d='m13.5 3c.2761424 0 .5.22385763.5.5s-.2238576.5-.5.5h-.5v10c0 .5522847-.4477153 1-1 1h-8c-.55228475 0-1-.4477153-1-1v-10h-.5c-.27614237 0-.5-.22385763-.5-.5s.22385763-.5.5-.5zm-1.5 1h-8v10h8zm-5 2v6h-1v-6zm3 0v6h-1v-6zm-.5-5c.27614237 0 .5.22385763.5.5s-.22385763.5-.5.5h-3c-.27614237 0-.5-.22385763-.5-.5s.22385763-.5.5-.5z' fill='%23c62828'/></svg>");
 }
 
 .dhis2-map-download .dhis2-map-ctrl-measure {


### PR DESCRIPTION
This PR improves the styles in the measurement dialog.

maps-gl is not based on react, so the SVGs are included inline. 

After this PR: 

<img width="297" alt="Screenshot 2021-03-02 at 11 37 34" src="https://user-images.githubusercontent.com/548708/109636422-dcacae00-7b4b-11eb-9962-3d1734310d79.png">

<img width="293" alt="Screenshot 2021-03-02 at 11 37 40" src="https://user-images.githubusercontent.com/548708/109636426-de767180-7b4b-11eb-93b3-872701761f21.png">

Before: 

<img width="294" alt="Screenshot 2021-03-02 at 11 38 11" src="https://user-images.githubusercontent.com/548708/109636396-d3bbdc80-7b4b-11eb-87ce-71f6a19064de.png">

<img width="292" alt="Screenshot 2021-03-02 at 11 38 16" src="https://user-images.githubusercontent.com/548708/109636397-d4ed0980-7b4b-11eb-842c-72e720f851d0.png">