### PR TITLE
fix: only set feature hover state if layer is still on map

### DIFF
--- a/src/layers/Layer.js
+++ b/src/layers/Layer.js
@@ -248,15 +248,18 @@ class Layer extends Evented {
     // Highlight a layer feature
     highlight(id) {
         const feature = id ? this.getFeature(id) : null
+        const map = this.getMap()
 
-        this.getMap().setHoverState(
-            feature
-                ? {
-                      id: feature.id,
-                      source: this.getId(),
-                  }
-                : null
-        )
+        if (map) {
+            map.setHoverState(
+                feature
+                    ? {
+                          id: feature.id,
+                          source: this.getId(),
+                      }
+                    : null
+            )
+        }
     }
 
     // Override if needed in subclass


### PR DESCRIPTION
This PR checks if layer is added to a map before setting hover state for a feature. Needed to support client side filtering. 