### PR TITLE
feat: allow features in EE layers to be filtered

### DIFF
--- a/src/layers/EarthEngine.js
+++ b/src/layers/EarthEngine.js
@@ -421,18 +421,22 @@ class EarthEngine extends Layer {
         }
     }
 
-    // Filter the org units features shown
-    filter(ids) {
-        const source = this.getMapGL().getSource(this.getId())
+    // Returns filtered features based on string ids
+    getFilteredFeatures(ids) {
         const features = this.getFeatures()
 
-        source.setData(
-            featureCollection(
-                Array.isArray(ids)
-                    ? features.filter(f => ids.includes(f.properties.id))
-                    : features
-            )
-        )
+        return Array.isArray(ids)
+            ? features.filter(f => ids.includes(f.properties.id))
+            : features
+    }
+
+    // Filter the org units features shown
+    filter(ids) {
+        const source = this.getSource()[this.getId()]
+
+        if (source) {
+            source.setData(featureCollection(getFilteredFeatures(ids)))
+        }
     }
 }
 

--- a/src/layers/EarthEngine.js
+++ b/src/layers/EarthEngine.js
@@ -44,16 +44,12 @@ class EarthEngine extends Layer {
 
     async createSource() {
         const id = this.getId()
-        const features = this.getFeatures()
 
-        this.featureCollection = this.getFeatureCollection(features)
+        this.featureCollection = this.getFeatureCollection()
 
-        this.image = await this.createImage()
+        const image = await this.createImage()
 
-        const { urlFormat } = await this.visualize(
-            this.image,
-            this.featureCollection
-        )
+        const { urlFormat } = await this.visualize(image)
 
         this.setSource(`${id}-raster`, {
             type: 'raster',
@@ -64,7 +60,7 @@ class EarthEngine extends Layer {
         if (this.options.data) {
             this.setSource(id, {
                 type: 'geojson',
-                data: featureCollection(features),
+                data: featureCollection(this.getFeatures()),
             })
         }
     }
@@ -174,8 +170,9 @@ class EarthEngine extends Layer {
     }
 
     // Create feature collection for org unit aggregations
-    getFeatureCollection(features) {
+    getFeatureCollection() {
         const { FeatureCollection } = this.ee
+        const features = this.getFeatures()
 
         return features.length
             ? FeatureCollection(
@@ -313,12 +310,12 @@ class EarthEngine extends Layer {
     }
 
     // Visualize image (turn into RGB)
-    visualize(eeImage, featureCollection) {
+    visualize(eeImage) {
         const { params } = this.options
 
         // Clip image to org unit features
-        if (featureCollection) {
-            eeImage = eeImage.clipToCollection(featureCollection)
+        if (this.featureCollection) {
+            eeImage = eeImage.clipToCollection(this.featureCollection)
         }
 
         return new Promise(resolve =>

--- a/src/layers/Layer.js
+++ b/src/layers/Layer.js
@@ -247,16 +247,20 @@ class Layer extends Evented {
 
     // Highlight a layer feature
     highlight(id) {
-        const feature = id ? this.getFeature(id) : null
+        const map = this.getMap()
 
-        this.getMap().setHoverState(
-            feature
-                ? {
-                      id: feature.id,
-                      source: this.getId(),
-                  }
-                : null
-        )
+        if (map) {
+            const feature = id ? this.getFeature(id) : null
+
+            map.setHoverState(
+                feature
+                    ? {
+                          id: feature.id,
+                          source: this.getId(),
+                      }
+                    : null
+            )
+        }
     }
 
     // Override if needed in subclass

--- a/src/layers/Layer.js
+++ b/src/layers/Layer.js
@@ -260,6 +260,9 @@ class Layer extends Evented {
     }
 
     // Override if needed in subclass
+    filter() {}
+
+    // Override if needed in subclass
     onAdd() {}
 
     // Override if needed in subclass

--- a/src/layers/__tests__/EarthEngine.spec.js
+++ b/src/layers/__tests__/EarthEngine.spec.js
@@ -247,4 +247,13 @@ describe('EarthEngine', () => {
 
         expect(features.some(f => f.geometry.type === 'Point')).toBe(false)
     })
+
+    it('Should filter features based on ids', async () => {
+        const layer = new EarthEngine(options)
+
+        expect(layer.getFilteredFeatures().length).toBe(3)
+        expect(layer.getFilteredFeatures([]).length).toBe(0)
+        expect(layer.getFilteredFeatures(['O6uvpzGd5pu']).length).toBe(1)
+        expect(layer.getFilteredFeatures(['O6uvpzGd5pu', 'abc']).length).toBe(1)
+    })
 })


### PR DESCRIPTION
This PR will allow org unit features in Earth Engine layers to be filtered. 

There is a new `filter(ids)` method where an array of string ids can be passed. This will update the map layer to only show the boundaries of the filtered features. If ids is `null` or `undefined`, all features will be shown. 

This will be used as a quick way to update map when the EE data table is filtered in https://github.com/dhis2/maps-app/pull/1537/

![ezgif com-gif-maker (4)](https://user-images.githubusercontent.com/548708/110532290-eb333080-811c-11eb-8a98-4fc0bca70f76.gif)

The PR also includes an extra check that the layer is still on the map before setting feature hover state. 