### PR TITLE
fix: compact attribution style

### DIFF
--- a/src/Map.css
+++ b/src/Map.css
@@ -42,3 +42,11 @@
 .mapboxgl-popup-close-button:focus {
     outline: none;
 }
+
+.mapboxgl-ctrl-attrib.mapboxgl-compact {
+    min-height: 24px;
+}
+
+.mapboxgl-ctrl-attrib-button:focus {
+    box-shadow: none;
+}


### PR DESCRIPTION
This PR fixes an issue where the attribution icon is "jumping" when expanded. 

After this PR: 

![ezgif com-gif-maker (5)](https://user-images.githubusercontent.com/548708/110605439-6cc0a800-8189-11eb-9aaa-a5cebc823d59.gif)
