### PR TITLE
fix: don't set opacity before layer is added to map

### DIFF
--- a/src/layers/EarthEngine.js
+++ b/src/layers/EarthEngine.js
@@ -415,7 +415,7 @@ class EarthEngine extends Layer {
         const layerId = `${id}-polygon`
         const mapgl = this.getMapGL()
 
-        if (mapgl.getLayer(layerId)) {
+        if (mapgl && mapgl.getLayer(layerId)) {
             // Clickable polygon layer should always be transparent
             mapgl.setPaintProperty(layerId, 'fill-opacity', 0)
         }

--- a/src/layers/Layer.js
+++ b/src/layers/Layer.js
@@ -227,7 +227,11 @@ class Layer extends Evented {
     }
 
     setOpacity(opacity) {
-        setLayersOpacity(this.getMapGL(), this.getId(), opacity)
+        const mapgl = this.getMapGL()
+
+        if (mapgl) {
+            setLayersOpacity(mapgl, this.getId(), opacity)
+        }
     }
 
     getBounds() {


### PR DESCRIPTION
This PR avoids an app crash when the opacity is changed before the layers are added to the map. There will be a separate PR in `maps-app` when this PR is merged. 