### PR TITLE
fix: icon label opacity

### DIFF
--- a/src/layers/Markers.js
+++ b/src/layers/Markers.js
@@ -33,7 +33,7 @@ class Markers extends Layer {
         }
 
         const config = {
-            id,
+            id: `${id}-icon`,
             type: 'symbol',
             source: id,
             layout: {
@@ -47,14 +47,6 @@ class Markers extends Layer {
             label ? addTextProperties(config, label, labelStyle) : config,
             true
         )
-    }
-
-    setOpacity(opacity) {
-        super.setOpacity(opacity)
-
-        if (this.isOnMap()) {
-            this.getMapGL().setPaintProperty(this.getId(), 'icon-opacity', opacity)
-        }
     }
 }
 

--- a/src/utils/opacity.js
+++ b/src/utils/opacity.js
@@ -1,33 +1,36 @@
 const properties = {
-    'raster': ['raster-opacity'],
-    'point': ['circle-opacity', 'circle-stroke-opacity'],
-    'polygon': ['fill-opacity'],
-    'line': ['line-opacity'],
-    'outline': ['line-opacity'],
-    'buffer': ['fill-opacity'],
+    raster: ['raster-opacity'],
+    point: ['circle-opacity', 'circle-stroke-opacity'],
+    polygon: ['fill-opacity'],
+    line: ['line-opacity'],
+    outline: ['line-opacity'],
+    buffer: ['fill-opacity'],
     'buffer-outline': ['line-opacity'],
-    'label': ['text-opacity'],
-    'icon': ['icon-opacity'],
-    'cluster': ['circle-opacity', 'circle-stroke-opacity'],
-    'count': ['text-opacity'],
+    label: ['text-opacity'],
+    icon: ['icon-opacity', 'text-opacity'],
+    cluster: ['circle-opacity', 'circle-stroke-opacity'],
+    count: ['text-opacity'],
 }
 
-const opacityFactor =  {
-    'buffer': 0.2,
+const opacityFactor = {
+    buffer: 0.2,
     'buffer-outline': 0.2,
 }
 
-const getOpacity = (key, opacity) =>  opacity * (opacityFactor[key] || 1)
+const getOpacity = (key, opacity) => opacity * (opacityFactor[key] || 1)
 
 export const setLayersOpacity = (mapgl, id, opacity) => {
     Object.keys(properties).forEach(key => {
         const layerId = `${id}-${key}`
 
         if (mapgl.getLayer(layerId)) {
-            properties[key].forEach(property => 
-                mapgl.setPaintProperty(layerId, property, getOpacity(key, opacity))
+            properties[key].forEach(property =>
+                mapgl.setPaintProperty(
+                    layerId,
+                    property,
+                    getOpacity(key, opacity)
+                )
             )
         }
     })
 }
-


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-10734

This PR makes sure that opacity is changed for all layers representing facilities (icon, buffer and label). 

After this PR: 
![labe-opacity](https://user-images.githubusercontent.com/548708/111910356-56f09400-8a61-11eb-9130-7714bd329fae.gif)

Before this PR: 
<img width="953" alt="Screenshot 2021-03-21 at 15 28 49" src="https://user-images.githubusercontent.com/548708/111910095-48ee4380-8a60-11eb-9709-42e49117cfab.png">
