### PR TITLE
fix: wait until donut cluster source is loaded for all tiles (DHIS2-10889)

### DIFF
--- a/src/layers/DonutCluster.js
+++ b/src/layers/DonutCluster.js
@@ -51,7 +51,11 @@ class DonutCluster extends Cluster {
     }
 
     onSourceData = evt => {
-        if (evt.sourceId === this.getId() && this.getSourceFeatures().length) {
+        if (
+            evt.sourceId === this.getId() &&
+            evt.isSourceLoaded &&
+            this.getSourceFeatures().length
+        ) {
             this.getMapGL().off('sourcedata', this.onSourceData)
             this.updateClusters()
         }


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-10889

This PR fixes an issue where donut clusters are not shown for parts of the map. 

Mapbox GL JS divides the the map surface into tiles, and the fix was to wait for all tiles to "load" before rendering the donut clusters (isSourceLoaded). 

After this PR: 
<img width="1103" alt="Screenshot 2021-04-13 at 18 04 04" src="https://user-images.githubusercontent.com/548708/114584231-bc136000-9c82-11eb-8ed7-50fbea4b8ac0.png">

Before: 
<img width="1103" alt="Screenshot 2021-04-13 at 18 06 05" src="https://user-images.githubusercontent.com/548708/114584448-fa108400-9c82-11eb-851d-afbad80c968c.png">
