### PR TITLE
BREAKING CHANGE: switch from Mapbox GL JS to MapLibre GL JS (DHIS2-11406)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,75 +1,75 @@
 {
-    "name": "@dhis2/maps-gl",
-    "version": "1.8.6",
-    "description": "A WebGL rendering engine for DHIS2 maps based on MapLibre GL JS.",
-    "publishConfig": {
-        "access": "public"
-    },
-    "files": [
-        "build/**"
-    ],
-    "main": "build/cjs/index.js",
-    "module": "build/es/index.js",
-    "repository": "https://github.com/dhis2/maps-gl",
-    "author": "Bjorn Sandvik <bjorn@dhis2.org>",
-    "maintainers": [
-        "Bjorn Sandvik <bjorn@dhis2.org>",
-        "Austin McGee <austin@dhis2.org>"
-    ],
-    "license": "BSD-3-Clause",
-    "dependencies": {
-        "@mapbox/sphericalmercator": "^1.1.0",
-        "@turf/area": "^6.3.0",
-        "@turf/bbox": "^6.3.0",
-        "@turf/buffer": "^6.3.0",
-        "@turf/center-of-mass": "^6.3.0",
-        "@turf/circle": "^6.3.0",
-        "@turf/length": "^6.3.0",
-        "fetch-jsonp": "^1.1.3",
-        "lodash.throttle": "^4.1.1",
-        "maplibre-gl": "^1.14.0",
-        "polylabel": "^1.1.0",
-        "suggestions": "^1.7.1",
-        "uuid": "^8.3.2"
-    },
-    "devDependencies": {
-        "@babel/cli": "^7.12.17",
-        "@babel/core": "^7.12.17",
-        "@babel/plugin-proposal-class-properties": "^7.3.4",
-        "@babel/plugin-proposal-object-rest-spread": "^7.3.4",
-        "@babel/plugin-transform-runtime": "^7.3.4",
-        "@babel/preset-env": "^7.12.17",
-        "@babel/runtime": "^7.3.4",
-        "@dhis2/cli-style": "^2.2.2",
-        "@types/jest": "^26.0.20",
-        "babel-jest": "^26.6.3",
-        "concurrently": "^5.1.0",
-        "husky": "^4.2.2",
-        "identity-obj-proxy": "^3.0.0",
-        "jest": "^26.6.3",
-        "rimraf": "^3.0.2"
-    },
-    "scripts": {
-        "format": "d2-style js apply --all --no-stage",
-        "clean": "rimraf ./build/*",
-        "build:commonjs": "BABEL_ENV=commonjs babel src --out-dir ./build/cjs --copy-files --verbose",
-        "build:modules": "BABEL_ENV=modules babel src --out-dir ./build/es --copy-files --verbose",
-        "build": "NODE_ENV=production yarn clean && yarn build:commonjs && yarn build:modules",
-        "watch": "NODE_ENV=development yarn clean && concurrently -n watch-cjs,watch-es \"yarn build:commonjs --watch\" \"yarn build:modules --watch\"",
-        "test": "jest src/*"
-    },
-    "husky": {
-        "hooks": {
-            "commit-msg": "d2-style commit check",
-            "pre-commit": "d2-style js apply"
-        }
-    },
-    "jest": {
-        "setupFiles": [
-            "./jest.stub.js"
-        ],
-        "moduleNameMapper": {
-            "\\.(css|less)$": "identity-obj-proxy"
-        }
+  "name": "@dhis2/maps-gl",
+  "version": "1.8.6",
+  "description": "A WebGL rendering engine for DHIS2 maps based on MapLibre GL JS.",
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "build/**"
+  ],
+  "main": "build/cjs/index.js",
+  "module": "build/es/index.js",
+  "repository": "https://github.com/dhis2/maps-gl",
+  "author": "Bjorn Sandvik <bjorn@dhis2.org>",
+  "maintainers": [
+    "Bjorn Sandvik <bjorn@dhis2.org>",
+    "Austin McGee <austin@dhis2.org>"
+  ],
+  "license": "BSD-3-Clause",
+  "dependencies": {
+    "@mapbox/sphericalmercator": "^1.1.0",
+    "@turf/area": "^6.3.0",
+    "@turf/bbox": "^6.3.0",
+    "@turf/buffer": "^6.3.0",
+    "@turf/center-of-mass": "^6.3.0",
+    "@turf/circle": "^6.3.0",
+    "@turf/length": "^6.3.0",
+    "fetch-jsonp": "^1.1.3",
+    "lodash.throttle": "^4.1.1",
+    "maplibre-gl": "^1.14.0",
+    "polylabel": "^1.1.0",
+    "suggestions": "^1.7.1",
+    "uuid": "^8.3.2"
+  },
+  "devDependencies": {
+    "@babel/cli": "^7.12.17",
+    "@babel/core": "^7.12.17",
+    "@babel/plugin-proposal-class-properties": "^7.3.4",
+    "@babel/plugin-proposal-object-rest-spread": "^7.3.4",
+    "@babel/plugin-transform-runtime": "^7.3.4",
+    "@babel/preset-env": "^7.12.17",
+    "@babel/runtime": "^7.3.4",
+    "@dhis2/cli-style": "^2.2.2",
+    "@types/jest": "^26.0.20",
+    "babel-jest": "^26.6.3",
+    "concurrently": "^5.1.0",
+    "husky": "^4.2.2",
+    "identity-obj-proxy": "^3.0.0",
+    "jest": "^26.6.3",
+    "rimraf": "^3.0.2"
+  },
+  "scripts": {
+    "format": "d2-style js apply --all --no-stage",
+    "clean": "rimraf ./build/*",
+    "build:commonjs": "BABEL_ENV=commonjs babel src --out-dir ./build/cjs --copy-files --verbose",
+    "build:modules": "BABEL_ENV=modules babel src --out-dir ./build/es --copy-files --verbose",
+    "build": "NODE_ENV=production yarn clean && yarn build:commonjs && yarn build:modules",
+    "watch": "NODE_ENV=development yarn clean && concurrently -n watch-cjs,watch-es \"yarn build:commonjs --watch\" \"yarn build:modules --watch\"",
+    "test": "jest src/*"
+  },
+  "husky": {
+    "hooks": {
+      "commit-msg": "d2-style commit check",
+      "pre-commit": "d2-style js apply"
     }
+  },
+  "jest": {
+    "setupFiles": [
+      "./jest.stub.js"
+    ],
+    "moduleNameMapper": {
+      "\\.(css|less)$": "identity-obj-proxy"
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -25,14 +25,12 @@
     "@turf/center-of-mass": "^6.3.0",
     "@turf/circle": "^6.3.0",
     "@turf/length": "^6.3.0",
-    "add": "^2.0.6",
     "fetch-jsonp": "^1.1.3",
     "lodash.throttle": "^4.1.1",
     "maplibre-gl": "^1.15.0",
     "polylabel": "^1.1.0",
     "suggestions": "^1.7.1",
-    "uuid": "^8.3.2",
-    "yarn": "^1.22.10"
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.17",

--- a/package.json
+++ b/package.json
@@ -25,12 +25,14 @@
     "@turf/center-of-mass": "^6.3.0",
     "@turf/circle": "^6.3.0",
     "@turf/length": "^6.3.0",
+    "add": "^2.0.6",
     "fetch-jsonp": "^1.1.3",
     "lodash.throttle": "^4.1.1",
-    "maplibre-gl": "^1.14.0",
+    "maplibre-gl": "^1.15.0",
     "polylabel": "^1.1.0",
     "suggestions": "^1.7.1",
-    "uuid": "^8.3.2"
+    "uuid": "^8.3.2",
+    "yarn": "^1.22.10"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.17",

--- a/package.json
+++ b/package.json
@@ -1,76 +1,75 @@
 {
-  "name": "@dhis2/maps-gl",
-  "version": "1.8.6",
-  "description": "A WebGL rendering engine for DHIS2 maps based on Mapbox GL JS.",
-  "publishConfig": {
-    "access": "public"
-  },
-  "files": [
-    "build/**"
-  ],
-  "main": "build/cjs/index.js",
-  "module": "build/es/index.js",
-  "repository": "https://github.com/dhis2/maps-gl",
-  "author": "Bjorn Sandvik <bjorn@dhis2.org>",
-  "maintainers": [
-    "Bjorn Sandvik <bjorn@dhis2.org>",
-    "Austin McGee <austin@dhis2.org>"
-  ],
-  "license": "BSD-3-Clause",
-  "dependencies": {
-    "@mapbox/sphericalmercator": "^1.1.0",
-    "@turf/area": "^6.3.0",
-    "@turf/bbox": "^6.3.0",
-    "@turf/buffer": "^6.3.0",
-    "@turf/center-of-mass": "^6.3.0",
-    "@turf/circle": "^6.3.0",
-    "@turf/length": "^6.3.0",
-    "fetch-jsonp": "^1.1.3",
-    "lodash.throttle": "^4.1.1",
-    "mapbox-gl": "^1.13.1",
-    "mapboxgl-spiderifier": "^1.0.9",
-    "polylabel": "^1.1.0",
-    "suggestions": "^1.7.1",
-    "uuid": "^8.3.2"
-  },
-  "devDependencies": {
-    "@babel/cli": "^7.12.17",
-    "@babel/core": "^7.12.17",
-    "@babel/plugin-proposal-class-properties": "^7.3.4",
-    "@babel/plugin-proposal-object-rest-spread": "^7.3.4",
-    "@babel/plugin-transform-runtime": "^7.3.4",
-    "@babel/preset-env": "^7.12.17",
-    "@babel/runtime": "^7.3.4",
-    "@dhis2/cli-style": "^2.2.2",
-    "@types/jest": "^26.0.20",
-    "babel-jest": "^26.6.3",
-    "concurrently": "^5.1.0",
-    "husky": "^4.2.2",
-    "identity-obj-proxy": "^3.0.0",
-    "jest": "^26.6.3",
-    "rimraf": "^3.0.2"
-  },
-  "scripts": {
-    "format": "d2-style js apply --all --no-stage",
-    "clean": "rimraf ./build/*",
-    "build:commonjs": "BABEL_ENV=commonjs babel src --out-dir ./build/cjs --copy-files --verbose",
-    "build:modules": "BABEL_ENV=modules babel src --out-dir ./build/es --copy-files --verbose",
-    "build": "NODE_ENV=production yarn clean && yarn build:commonjs && yarn build:modules",
-    "watch": "NODE_ENV=development yarn clean && concurrently -n watch-cjs,watch-es \"yarn build:commonjs --watch\" \"yarn build:modules --watch\"",
-    "test": "jest src/*"
-  },
-  "husky": {
-    "hooks": {
-      "commit-msg": "d2-style commit check",
-      "pre-commit": "d2-style js apply"
-    }
-  },
-  "jest": {
-    "setupFiles": [
-      "./jest.stub.js"
+    "name": "@dhis2/maps-gl",
+    "version": "1.8.6",
+    "description": "A WebGL rendering engine for DHIS2 maps based on MapLibre GL JS.",
+    "publishConfig": {
+        "access": "public"
+    },
+    "files": [
+        "build/**"
     ],
-    "moduleNameMapper": {
-      "\\.(css|less)$": "identity-obj-proxy"
+    "main": "build/cjs/index.js",
+    "module": "build/es/index.js",
+    "repository": "https://github.com/dhis2/maps-gl",
+    "author": "Bjorn Sandvik <bjorn@dhis2.org>",
+    "maintainers": [
+        "Bjorn Sandvik <bjorn@dhis2.org>",
+        "Austin McGee <austin@dhis2.org>"
+    ],
+    "license": "BSD-3-Clause",
+    "dependencies": {
+        "@mapbox/sphericalmercator": "^1.1.0",
+        "@turf/area": "^6.3.0",
+        "@turf/bbox": "^6.3.0",
+        "@turf/buffer": "^6.3.0",
+        "@turf/center-of-mass": "^6.3.0",
+        "@turf/circle": "^6.3.0",
+        "@turf/length": "^6.3.0",
+        "fetch-jsonp": "^1.1.3",
+        "lodash.throttle": "^4.1.1",
+        "maplibre-gl": "^1.14.0",
+        "polylabel": "^1.1.0",
+        "suggestions": "^1.7.1",
+        "uuid": "^8.3.2"
+    },
+    "devDependencies": {
+        "@babel/cli": "^7.12.17",
+        "@babel/core": "^7.12.17",
+        "@babel/plugin-proposal-class-properties": "^7.3.4",
+        "@babel/plugin-proposal-object-rest-spread": "^7.3.4",
+        "@babel/plugin-transform-runtime": "^7.3.4",
+        "@babel/preset-env": "^7.12.17",
+        "@babel/runtime": "^7.3.4",
+        "@dhis2/cli-style": "^2.2.2",
+        "@types/jest": "^26.0.20",
+        "babel-jest": "^26.6.3",
+        "concurrently": "^5.1.0",
+        "husky": "^4.2.2",
+        "identity-obj-proxy": "^3.0.0",
+        "jest": "^26.6.3",
+        "rimraf": "^3.0.2"
+    },
+    "scripts": {
+        "format": "d2-style js apply --all --no-stage",
+        "clean": "rimraf ./build/*",
+        "build:commonjs": "BABEL_ENV=commonjs babel src --out-dir ./build/cjs --copy-files --verbose",
+        "build:modules": "BABEL_ENV=modules babel src --out-dir ./build/es --copy-files --verbose",
+        "build": "NODE_ENV=production yarn clean && yarn build:commonjs && yarn build:modules",
+        "watch": "NODE_ENV=development yarn clean && concurrently -n watch-cjs,watch-es \"yarn build:commonjs --watch\" \"yarn build:modules --watch\"",
+        "test": "jest src/*"
+    },
+    "husky": {
+        "hooks": {
+            "commit-msg": "d2-style commit check",
+            "pre-commit": "d2-style js apply"
+        }
+    },
+    "jest": {
+        "setupFiles": [
+            "./jest.stub.js"
+        ],
+        "moduleNameMapper": {
+            "\\.(css|less)$": "identity-obj-proxy"
+        }
     }
-  }
 }

--- a/src/Map.css
+++ b/src/Map.css
@@ -3,7 +3,7 @@
     -webkit-tap-highlight-color: transparent;
 }
 
-.dhis2-map-split-view .mapboxgl-ctrl-group {
+.dhis2-map-split-view .maplibregl-ctrl-group {
     position: absolute;
     top: 10px;
     right: 10px;
@@ -13,15 +13,15 @@
     z-index: 20;
 }
 
-.mapboxgl-popup-close-button:focus {
+.maplibregl-popup-close-button:focus {
     outline: none;
 }
 
-.dhis2-map-popup .mapboxgl-popup-content {
+.dhis2-map-popup .maplibregl-popup-content {
     box-shadow: 0 3px 14px rgba(0, 0, 0, 0.4);
 }
 
-.dhis2-map-popup .mapboxgl-popup-content em {
+.dhis2-map-popup .maplibregl-popup-content em {
     font-style: normal;
     font-weight: bold;
 }
@@ -39,14 +39,14 @@
     padding-right: 5px;
 }
 
-.mapboxgl-popup-close-button:focus {
+.maplibregl-popup-close-button:focus {
     outline: none;
 }
 
-.mapboxgl-ctrl-attrib.mapboxgl-compact {
+.maplibregl-ctrl-attrib.maplibregl-compact {
     min-height: 24px;
 }
 
-.mapboxgl-ctrl-attrib-button:focus {
+.maplibregl-ctrl-attrib-button:focus {
     box-shadow: none;
 }

--- a/src/Map.js
+++ b/src/Map.js
@@ -1,5 +1,5 @@
-import { Evented, Map } from 'mapbox-gl'
-import 'mapbox-gl/dist/mapbox-gl.css'
+import { Evented, Map } from 'maplibre-gl'
+import 'maplibre-gl/dist/maplibre-gl.css'
 import Layer from './layers/Layer'
 import layerTypes from './layers/layerTypes'
 import controlTypes from './controls/controlTypes'
@@ -37,7 +37,7 @@ export class MapGL extends Evented {
                 glyphs:
                     'https://fonts.openmaptiles.org/{fontstack}/{range}.pbf', // TODO: Host ourseleves
             },
-            maxZoom: 18,
+            maxZoom: 10,
             preserveDrawingBuffer: true, // TODO: requred for map download, but reduced performance
             attributionControl: false,
             locale: controlsLocale,

--- a/src/Map.js
+++ b/src/Map.js
@@ -37,7 +37,7 @@ export class MapGL extends Evented {
                 glyphs:
                     'https://fonts.openmaptiles.org/{fontstack}/{range}.pbf', // TODO: Host ourseleves
             },
-            maxZoom: 10,
+            maxZoom: 18,
             preserveDrawingBuffer: true, // TODO: requred for map download, but reduced performance
             attributionControl: false,
             locale: controlsLocale,

--- a/src/__tests__/Map.spec.js
+++ b/src/__tests__/Map.spec.js
@@ -1,6 +1,6 @@
 import Map from '../Map'
 
-jest.mock('mapbox-gl', () => ({
+jest.mock('maplibre-gl', () => ({
     Map: () => mockMapGL,
     Evented: () => {},
     Marker: () => {},

--- a/src/controls/Controls.css
+++ b/src/controls/Controls.css
@@ -1,36 +1,36 @@
-.dhis2-map .mapboxgl-ctrl-scale {
+.dhis2-map .maplibregl-ctrl-scale {
     margin-bottom: 5px;
 }
 
-.dhis2-map .mapboxgl-ctrl-attrib.mapboxgl-compact {
+.dhis2-map .maplibregl-ctrl-attrib.maplibregl-compact {
     margin-bottom: 3px;
     margin-right: 3px;
 }
 
-.dhis2-map-split-view .mapboxgl-ctrl-group {
+.dhis2-map-split-view .maplibregl-ctrl-group {
     box-shadow: none;
 }
 
-.dhis2-map-split-view .mapboxgl-ctrl-zoom-in,
-.dhis2-map-split-view .mapboxgl-ctrl-zoom-out,
-.dhis2-map-split-view .mapboxgl-ctrl-compass,
-.dhis2-map-split-view .mapboxgl-ctrl-fullscreen,
-.dhis2-map-split-view .mapboxgl-ctrl-shrink {
+.dhis2-map-split-view .maplibregl-ctrl-zoom-in,
+.dhis2-map-split-view .maplibregl-ctrl-zoom-out,
+.dhis2-map-split-view .maplibregl-ctrl-compass,
+.dhis2-map-split-view .maplibregl-ctrl-fullscreen,
+.dhis2-map-split-view .maplibregl-ctrl-shrink {
     position: absolute;
     right: 0;
     background: #fff;
     box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.1);
 }
 
-.dhis2-map-split-view .mapboxgl-ctrl-zoom-in:not(:disabled):hover,
-.dhis2-map-split-view .mapboxgl-ctrl-zoom-out:not(:disabled):hover,
-.dhis2-map-split-view .mapboxgl-ctrl-compass:not(:disabled):hover,
-.dhis2-map-split-view .mapboxgl-ctrl-fullscreen:not(:disabled):hover,
-.dhis2-map-split-view .mapboxgl-ctrl-shrink:not(:disabled):hover {
+.dhis2-map-split-view .maplibregl-ctrl-zoom-in:not(:disabled):hover,
+.dhis2-map-split-view .maplibregl-ctrl-zoom-out:not(:disabled):hover,
+.dhis2-map-split-view .maplibregl-ctrl-compass:not(:disabled):hover,
+.dhis2-map-split-view .maplibregl-ctrl-fullscreen:not(:disabled):hover,
+.dhis2-map-split-view .maplibregl-ctrl-shrink:not(:disabled):hover {
     background-color: #f3f3f3;
 }
 
-.dhis2-map-split-view .mapboxgl-ctrl-zoom-in {
+.dhis2-map-split-view .maplibregl-ctrl-zoom-in {
     top: 0;
     background: #fff;
     border-top-left-radius: 3px;
@@ -38,26 +38,26 @@
     z-index: 1002;
 }
 
-.dhis2-map-split-view .mapboxgl-ctrl-zoom-out {
+.dhis2-map-split-view .maplibregl-ctrl-zoom-out {
     top: 29px;
     z-index: 1001;
 }
 
-.dhis2-map-split-view .mapboxgl-ctrl-compass {
+.dhis2-map-split-view .maplibregl-ctrl-compass {
     top: 58px;
     border-bottom-left-radius: 3px;
     border-bottom-right-radius: 3px;
     z-index: 1000;
 }
 
-.dhis2-map-split-view .mapboxgl-ctrl-fullscreen,
-.dhis2-map-split-view .mapboxgl-ctrl-shrink {
+.dhis2-map-split-view .maplibregl-ctrl-fullscreen,
+.dhis2-map-split-view .maplibregl-ctrl-shrink {
     top: 98px;
     border-radius: 3px;
 }
 
-.dhis2-map-plugin .dhis2-map-split-view .mapboxgl-ctrl-fullscreen,
-.dhis2-map-plugin .dhis2-map-split-view .mapboxgl-ctrl-shrink {
+.dhis2-map-plugin .dhis2-map-split-view .maplibregl-ctrl-fullscreen,
+.dhis2-map-plugin .dhis2-map-split-view .maplibregl-ctrl-shrink {
     top: 69px;
 }
 
@@ -74,7 +74,7 @@
     right: 10px;
 }
 
-.dhis2-map-split-view .mapboxgl-ctrl-attrib {
+.dhis2-map-split-view .maplibregl-ctrl-attrib {
     position: absolute;
     right: 1px;
     bottom: 1px;
@@ -82,20 +82,20 @@
     margin: 0;
 }
 
-.dhis2-map-split-view .mapboxgl-ctrl-attrib.mapboxgl-compact:hover {
+.dhis2-map-split-view .maplibregl-ctrl-attrib.maplibregl-compact:hover {
     height: 24px;
     padding-top: 4px;
 }
 
 .dhis2-map-split-view
-    .mapboxgl-ctrl-attrib.mapboxgl-compact:hover
-    .mapboxgl-ctrl-attrib-inner {
+    .maplibregl-ctrl-attrib.maplibregl-compact:hover
+    .maplibregl-ctrl-attrib-inner {
     position: relative;
     right: 0;
     padding: 2px 8px;
 }
 
-.dhis2-map-split-view .mapboxgl-ctrl-attrib.mapboxgl-compact:after {
+.dhis2-map-split-view .maplibregl-ctrl-attrib.maplibregl-compact:after {
     right: 0;
     bottom: 0;
 }
@@ -104,22 +104,22 @@
     display: none;
 }
 
-.dhis2-map-download .mapboxgl-ctrl-zoom-in,
-.dhis2-map-download .mapboxgl-ctrl-zoom-out,
-.dhis2-map-download .mapboxgl-ctrl-compass,
-.dhis2-map-download .mapboxgl-ctrl-fullscreen {
+.dhis2-map-download .maplibregl-ctrl-zoom-in,
+.dhis2-map-download .maplibregl-ctrl-zoom-out,
+.dhis2-map-download .maplibregl-ctrl-compass,
+.dhis2-map-download .maplibregl-ctrl-fullscreen {
     display: none;
 }
 
-.dhis2-map-download .mapboxgl-ctrl-attrib {
+.dhis2-map-download .maplibregl-ctrl-attrib {
     white-space: nowrap;
 }
 
-.dhis2-map-plugin .mapboxgl-ctrl-compass {
+.dhis2-map-plugin .maplibregl-ctrl-compass {
     display: none;
 }
 
-.dhis2-map-plugin .mapboxgl-ctrl-zoom-out {
+.dhis2-map-plugin .maplibregl-ctrl-zoom-out {
     border-bottom-left-radius: 3px;
     border-bottom-right-radius: 3px;
 }

--- a/src/controls/FitBounds.js
+++ b/src/controls/FitBounds.js
@@ -22,7 +22,7 @@ class FitBoundsControl {
         const label = mapgl._getUIString('FitBoundsControl.ZoomToContent')
         const container = document.createElement('div')
 
-        container.className = 'mapboxgl-ctrl mapboxgl-ctrl-group'
+        container.className = 'maplibregl-ctrl maplibregl-ctrl-group'
 
         const button = document.createElement('div')
 

--- a/src/controls/Fullscreen.js
+++ b/src/controls/Fullscreen.js
@@ -1,4 +1,4 @@
-import { FullscreenControl } from 'mapbox-gl'
+import { FullscreenControl } from 'maplibre-gl'
 
 // Extended to include map name and legend in fullscreen for dashboard maps
 class Fullscreen extends FullscreenControl {

--- a/src/controls/Measure.js
+++ b/src/controls/Measure.js
@@ -27,7 +27,7 @@ class MeasureControl {
     onAdd() {
         this._container = createElement(
             'div',
-            'mapboxgl-ctrl mapboxgl-ctrl-group'
+            'maplibregl-ctrl maplibregl-ctrl-group'
         )
         this._setupUI()
 
@@ -47,7 +47,7 @@ class MeasureControl {
 
         this._button = createElement(
             'button',
-            'mapboxgl-ctrl-icon dhis2-map-ctrl-measure',
+            'maplibregl-ctrl-icon dhis2-map-ctrl-measure',
             '',
             this._container
         )

--- a/src/controls/Navigation.js
+++ b/src/controls/Navigation.js
@@ -1,14 +1,14 @@
-import { NavigationControl } from 'mapbox-gl'
+import { NavigationControl } from 'maplibre-gl'
 
 const defaultOptions = {
-    visualizePitch: true
+    visualizePitch: true,
 }
 
-// Extended to reset pitch 
+// Extended to reset pitch
 class Navigation extends NavigationControl {
     constructor(options = {}) {
-        super({...defaultOptions, ...options})
+        super({ ...defaultOptions, ...options })
     }
 }
 
-export default  Navigation
+export default Navigation

--- a/src/controls/Search.css
+++ b/src/controls/Search.css
@@ -83,8 +83,8 @@
     font-size: 12px;
 }
 
-.mapboxgl-ctrl-bottom-left .dhis2-map-ctrl-search ul,
-.mapboxgl-ctrl-bottom-right .dhis2-map-ctrl-search ul {
+.maplibregl-ctrl-bottom-left .dhis2-map-ctrl-search ul,
+.maplibregl-ctrl-bottom-right .dhis2-map-ctrl-search ul {
     top: auto;
     bottom: 100%;
 }

--- a/src/controls/Search.js
+++ b/src/controls/Search.js
@@ -49,7 +49,7 @@ class SearchControl {
         const label = map._getUIString('SearchControl.SearchForPlace')
 
         const el = (this._container = document.createElement('div'))
-        el.className = 'mapboxgl-ctrl dhis2-map-ctrl-search'
+        el.className = 'maplibregl-ctrl dhis2-map-ctrl-search'
 
         const icon = document.createElement('span')
         icon.className = 'geocoder-icon geocoder-icon-search'

--- a/src/controls/Search.js
+++ b/src/controls/Search.js
@@ -1,4 +1,4 @@
-import { Popup } from 'mapbox-gl'
+import { Popup } from 'maplibre-gl'
 import Typeahead from 'suggestions'
 import './Search.css'
 

--- a/src/controls/controlTypes.js
+++ b/src/controls/controlTypes.js
@@ -1,4 +1,4 @@
-import { AttributionControl, ScaleControl } from 'mapbox-gl'
+import { AttributionControl, ScaleControl } from 'maplibre-gl'
 import Navigation from './Navigation'
 import Search from './Search'
 import Measure from './Measure'

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ import getEarthEngineApi from './utils/eeapi'
 import { getLabelPosition } from './utils/labels'
 
 /**
- *  Wrapper around Mapbox GL JS for DHIS2 Maps
+ *  Wrapper around MapLibre GL JS for DHIS2 Maps
  */
 
 export const layerTypes = Object.keys(supportedLayers)

--- a/src/layers/BingLayer.css
+++ b/src/layers/BingLayer.css
@@ -4,15 +4,15 @@
     left: 3px;
 }
 
-.dhis2-map-bing .mapboxgl-ctrl-bottom-left {
+.dhis2-map-bing .maplibregl-ctrl-bottom-left {
     left: 60px;
 }
 
 /* Bing logo is blocked by CORS policy */
-.dhis2-map-download .dhis2-map-bing-logo  {
+.dhis2-map-download .dhis2-map-bing-logo {
     display: none;
 }
 
-.dhis2-map-download .dhis2-map-bing .mapboxgl-ctrl-bottom-left {
+.dhis2-map-download .dhis2-map-bing .maplibregl-ctrl-bottom-left {
     left: 0;
 }

--- a/src/layers/ClientCluster.js
+++ b/src/layers/ClientCluster.js
@@ -1,4 +1,3 @@
-
 import Cluster from './Cluster'
 import { featureCollection } from '../utils/geometry'
 import { clusterLayer, clusterCountLayer } from '../utils/layers'
@@ -51,7 +50,7 @@ class ClientCluster extends Cluster {
         const { feature } = evt
 
         if (!feature.properties.cluster) {
-            // Hack until Mapbox GL JS support string ids
+            // Hack until MapLibre GL JS support string ids
             // https://github.com/mapbox/mapbox-gl-js/issues/2716
             if (
                 typeof feature.id === 'number' &&
@@ -77,7 +76,6 @@ class ClientCluster extends Cluster {
             this.updatePolygons()
         }
     }
-    
 
     // Returns all features in a cluster
     getClusterFeatures = clusterId =>

--- a/src/layers/DonutCluster.js
+++ b/src/layers/DonutCluster.js
@@ -65,7 +65,7 @@ class DonutCluster extends Cluster {
         const { feature } = evt
 
         if (!feature.properties.cluster) {
-            // Hack until Mapbox GL JS support string ids
+            // Hack until MapLibre GL JS support string ids
             // https://github.com/mapbox/mapbox-gl-js/issues/2716
             if (
                 typeof feature.id === 'number' &&

--- a/src/layers/DonutMarker.js
+++ b/src/layers/DonutMarker.js
@@ -1,4 +1,4 @@
-import { Marker } from 'mapbox-gl'
+import { Marker } from 'maplibre-gl'
 
 // Creates a donut marker component
 class DonutMarker extends Marker {

--- a/src/layers/EarthEngine.js
+++ b/src/layers/EarthEngine.js
@@ -178,7 +178,7 @@ class EarthEngine extends Layer {
             ? FeatureCollection(
                   features.map(f => ({
                       ...f,
-                      id: f.properties.id, // EE requires id to be string, Mapbox integer
+                      id: f.properties.id, // EE requires id to be string, MapLibre integer
                   }))
               )
             : null

--- a/src/layers/Layer.js
+++ b/src/layers/Layer.js
@@ -1,6 +1,6 @@
 import { v4 as uuid } from 'uuid'
 import bbox from '@turf/bbox'
-import { Evented } from 'mapbox-gl'
+import { Evented } from 'maplibre-gl'
 import { addImages } from '../utils/images'
 import { featureCollection } from '../utils/geometry'
 import { bufferSource } from '../utils/buffers'

--- a/src/layers/LayerGroup.js
+++ b/src/layers/LayerGroup.js
@@ -1,4 +1,4 @@
-import { Evented } from 'mapbox-gl'
+import { Evented } from 'maplibre-gl'
 import { getBoundsFromLayers } from '../utils/geometry'
 
 class LayerGroup extends Evented {

--- a/src/layers/Spider.js
+++ b/src/layers/Spider.js
@@ -1,6 +1,5 @@
-import { Point } from 'mapbox-gl'
-import MapboxglSpiderifier from 'mapboxgl-spiderifier'
-import 'mapboxgl-spiderifier/index.css'
+import { Point } from 'maplibre-gl'
+import spiderifier from '../utils/spiderifier'
 import { eventStrokeColor as strokeColor, strokeWidth } from '../utils/style'
 
 const Spider = function(map, options) {
@@ -69,14 +68,14 @@ const Spider = function(map, options) {
     const onClick = (evt, leg) => {
         evt.stopPropagation()
 
-        const { feature, mapboxMarker, param } = leg
+        const { feature, marker, param } = leg
         const { angle, legLength } = param
         const length = legLength + options.radius
         const offset = new Point(
             length * Math.cos(angle),
             length * Math.sin(angle)
         )
-        const point = map.project(mapboxMarker.getLngLat()).add(offset)
+        const point = map.project(marker.getLngLat()).add(offset)
         const { lng, lat } = map.unproject(point)
 
         options.onClick({
@@ -87,7 +86,7 @@ const Spider = function(map, options) {
         })
     }
 
-    spider = new MapboxglSpiderifier(map, {
+    spider = spiderifier(map, {
         animate: true,
         animationSpeed: 200,
         customPin: true,

--- a/src/ui/Label.css
+++ b/src/ui/Label.css
@@ -1,8 +1,8 @@
-.dhis2-map-label .mapboxgl-popup-tip {
+.dhis2-map-label .maplibregl-popup-tip {
     display: none;
 }
 
-.dhis2-map-label .mapboxgl-popup-content {
+.dhis2-map-label .maplibregl-popup-content {
     padding: 2px 5px;
     box-shadow: 0px 1px 3px 0px rgba(0, 0, 0, 0.2),
         0px 1px 1px 0px rgba(0, 0, 0, 0.14),

--- a/src/ui/Label.js
+++ b/src/ui/Label.js
@@ -1,4 +1,4 @@
-import { Popup } from 'mapbox-gl'
+import { Popup } from 'maplibre-gl'
 import './Label.css'
 
 const defaultOptions = {

--- a/src/ui/Label.js
+++ b/src/ui/Label.js
@@ -9,7 +9,7 @@ const defaultOptions = {
     className: 'dhis2-map-label',
 }
 
-// Extends Mapbox GL Popup to create a label used for hover/tooltip
+// Extends MapLibre GL Popup to create a label used for hover/tooltip
 // Extends https://github.com/mapbox/mapbox-gl-js/blob/master/src/ui/popup.js
 class Label extends Popup {
     constructor(options) {

--- a/src/ui/Popup.js
+++ b/src/ui/Popup.js
@@ -1,4 +1,4 @@
-import { Popup as PopupGL } from 'mapbox-gl'
+import { Popup as PopupGL } from 'maplibre-gl'
 
 const defaultOptions = {
     maxWidth: 'auto',

--- a/src/utils/geometry.js
+++ b/src/utils/geometry.js
@@ -1,4 +1,4 @@
-import { LngLatBounds } from 'mapbox-gl'
+import { LngLatBounds } from 'maplibre-gl'
 
 export const isPoint = feature => feature.geometry.type === 'Point'
 

--- a/src/utils/spiderifier.css
+++ b/src/utils/spiderifier.css
@@ -1,3 +1,22 @@
+/*
+ * This file is based on https://github.com/bewithjonam/maplibregl-spiderifier (MIT License)
+ * It was adapted to support maplibre-gl
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 manoj kumar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ */
+
 .spider-leg-container {
     width: 1px;
     height: 1px;

--- a/src/utils/spiderifier.css
+++ b/src/utils/spiderifier.css
@@ -1,0 +1,75 @@
+.spider-leg-container {
+    width: 1px;
+    height: 1px;
+    overflow: display;
+    will-change: transform;
+}
+
+.spider-leg-container:hover {
+    cursor: pointer;
+}
+
+.spider-leg-container .spider-leg-pin {
+    position: relative;
+    z-index: 1;
+}
+
+.spider-leg-container .spider-leg-pin.default-spider-pin {
+    position: relative;
+    width: 25px;
+    height: 41px;
+    margin-left: -11.5px;
+    margin-top: -38.5px;
+}
+
+.spider-leg-container .spider-leg-line {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 2px;
+    background-color: #343434;
+    opacity: 0.45;
+    transform-origin: bottom;
+    z-index: 0;
+    height: 0;
+}
+
+.spider-leg-container:hover .spider-leg-line {
+    opacity: 1;
+}
+
+/* Animations specific styles */
+
+.spider-leg-container.animate {
+    -webkit-transition: margin 0.15s linear;
+    -moz-transition: margin 0.15s linear;
+    -ms-transition: margin 0.15s linear;
+    -o-transition: margin 0.15s linear;
+    transition: margin 0.15s linear;
+}
+
+.spider-leg-container.initial,
+.spider-leg-container.exit {
+    margin-left: 0 !important;
+    margin-top: 0 !important;
+    height: 0;
+}
+
+.spider-leg-container.animate .spider-leg-line {
+    -webkit-transition: all 0.15s linear;
+    -moz-transition: all 0.15s linear;
+    -ms-transition: all 0.15s linear;
+    -o-transition: all 0.15s linear;
+    transition: all 0.15s linear;
+
+    -webkit-transition-delay: inherit;
+    -moz-transition-delay: inherit;
+    -ms-transition-delay: inherit;
+    -o-transition-delay: inherit;
+    transition-delay: inherit;
+}
+
+.spider-leg-container.animate.initial .spider-leg-line,
+.spider-leg-container.animate.exit .spider-leg-line {
+    height: 0 !important;
+}

--- a/src/utils/spiderifier.js
+++ b/src/utils/spiderifier.js
@@ -1,0 +1,214 @@
+import { Marker } from 'maplibre-gl'
+import './spiderifier.css'
+
+/*
+ * This file is based on https://github.com/bewithjonam/mapboxgl-spiderifier (MIT License)
+ * It was adapted to support maplibre-gl-ls
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016 manoj kumar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ */
+
+// Utility
+const util = {
+    each: (array, iterator) => {
+        if (!array || !array.length) {
+            return []
+        }
+        for (let i = 0; i < array.length; i++) {
+            iterator(array[i], i)
+        }
+    },
+    eachTimes: (count, iterator) => {
+        if (!count) {
+            return []
+        }
+        for (let i = 0; i < count; i++) {
+            iterator(i)
+        }
+    },
+    map: (array, iterator) => {
+        const result = []
+        util.each(array, (item, i) => result.push(iterator(item, i)))
+        return result
+    },
+    mapTimes: (count, iterator) => {
+        const result = []
+        util.eachTimes(count, i => result.push(iterator(i)))
+        return result
+    },
+}
+
+const spiderifier = (map, userOptions) => {
+    const options = {
+        animate: false, // to animate the spiral
+        animationSpeed: 0, // animation speed in milliseconds
+        customPin: false, // If false, sets a default icon for pins in spider legs.
+        initializeLeg: () => {},
+        onClick: () => {},
+        // --- <SPIDER TUNING Params>
+        // circleSpiralSwitchover: show spiral instead of circle from this marker count upwards
+        // 0 -> always spiral; Infinity -> always circle
+        circleSpiralSwitchover: 9,
+        circleFootSeparation: 25, // related to circumference of circle
+        spiralFootSeparation: 28, // related to size of spiral (experiment!)
+        spiralLengthStart: 15, // ditto
+        spiralLengthFactor: 4, // ditto
+        // ---
+        ...userOptions,
+    }
+
+    const twoPi = Math.PI * 2
+    let previousSpiderLegs = []
+
+    // Private:
+    const unspiderfy = () => {
+        util.each(previousSpiderLegs.reverse(), (spiderLeg, index) => {
+            if (options.animate) {
+                spiderLeg.elements.container.style['transitionDelay'] =
+                    (options.animationSpeed /
+                        1000 /
+                        previousSpiderLegs.length) *
+                        index +
+                    's'
+                spiderLeg.elements.container.className += ' exit'
+                setTimeout(
+                    () => spiderLeg.marker.remove(),
+                    options.animationSpeed + 100
+                ) //Wait for 100ms more before clearing the DOM
+            } else {
+                spiderLeg.marker.remove()
+            }
+        })
+        previousSpiderLegs = []
+    }
+
+    const spiderfy = (latLng, features) => {
+        const spiderLegParams = generateSpiderLegParams(features.length)
+
+        unspiderfy()
+
+        const spiderLegs = util.map(features, (feature, index) => {
+            const param = spiderLegParams[index]
+            const elements = createMarkerElements(param, feature)
+            const marker = new Marker(elements.container).setLngLat(latLng)
+            const spiderLeg = { feature, elements, marker, param }
+
+            options.initializeLeg(spiderLeg)
+
+            elements.container.onclick = e => options.onClick(e, spiderLeg)
+
+            return spiderLeg
+        })
+
+        util.each(spiderLegs.reverse(), spiderLeg =>
+            spiderLeg.marker.addTo(map)
+        )
+
+        if (options.animate) {
+            setTimeout(() => {
+                util.each(spiderLegs.reverse(), (spiderLeg, index) => {
+                    spiderLeg.elements.container.className = (
+                        spiderLeg.elements.container.className || ''
+                    ).replace('initial', '')
+                    spiderLeg.elements.container.style['transitionDelay'] =
+                        (options.animationSpeed / 1000 / spiderLegs.length) *
+                            index +
+                        's'
+                })
+            })
+        }
+
+        previousSpiderLegs = spiderLegs
+    }
+
+    const generateSpiderLegParams = count => {
+        if (count >= options.circleSpiralSwitchover) {
+            return generateSpiralParams(count)
+        } else {
+            return generateCircleParams(count)
+        }
+    }
+
+    const generateSpiralParams = count => {
+        let legLength = options.spiralLengthStart
+        let angle = 0
+
+        return util.mapTimes(count, index => {
+            angle =
+                angle +
+                (options.spiralFootSeparation / legLength + index * 0.0005)
+
+            const pt = {
+                x: legLength * Math.cos(angle),
+                y: legLength * Math.sin(angle),
+                angle: angle,
+                legLength: legLength,
+                index: index,
+            }
+
+            legLength = legLength + (twoPi * options.spiralLengthFactor) / angle
+
+            return pt
+        })
+    }
+
+    const generateCircleParams = count => {
+        const circumference = options.circleFootSeparation * (2 + count)
+        const legLength = circumference / twoPi // = radius from circumference
+        const angleStep = twoPi / count
+
+        return util.mapTimes(count, index => {
+            const angle = index * angleStep
+            const x = legLength * Math.cos(angle)
+            const y = legLength * Math.sin(angle)
+
+            return { x, y, angle, legLength, index }
+        })
+    }
+
+    const createMarkerElements = spiderLegParam => {
+        const containerElem = document.createElement('div')
+        const pinElem = document.createElement('div')
+        const lineElem = document.createElement('div')
+
+        containerElem.className =
+            'spider-leg-container' +
+            (options.animate ? ' animate initial ' : ' ')
+        lineElem.className = 'spider-leg-line'
+        pinElem.className =
+            'spider-leg-pin' + (options.customPin ? '' : ' default-spider-pin')
+
+        containerElem.appendChild(lineElem)
+        containerElem.appendChild(pinElem)
+
+        containerElem.style['margin-left'] = spiderLegParam.x + 'px'
+        containerElem.style['margin-top'] = spiderLegParam.y + 'px'
+
+        lineElem.style.height = spiderLegParam.legLength + 'px'
+        lineElem.style.transform =
+            'rotate(' + (spiderLegParam.angle - Math.PI / 2) + 'rad)'
+
+        return { container: containerElem, line: lineElem, pin: pinElem }
+    }
+
+    // Public
+    return {
+        spiderfy,
+        unspiderfy,
+        each: callback => util.each(previousSpiderLegs, callback),
+    }
+}
+
+export default spiderifier

--- a/src/utils/spiderifier.js
+++ b/src/utils/spiderifier.js
@@ -3,7 +3,7 @@ import './spiderifier.css'
 
 /*
  * This file is based on https://github.com/bewithjonam/maplibregl-spiderifier (MIT License)
- * It was adapted to support maplibre-gl-ls
+ * It was adapted to support maplibre-gl
  *
  * MIT License
  *

--- a/src/utils/spiderifier.js
+++ b/src/utils/spiderifier.js
@@ -2,7 +2,7 @@ import { Marker } from 'maplibre-gl'
 import './spiderifier.css'
 
 /*
- * This file is based on https://github.com/bewithjonam/mapboxgl-spiderifier (MIT License)
+ * This file is based on https://github.com/bewithjonam/maplibregl-spiderifier (MIT License)
  * It was adapted to support maplibre-gl-ls
  *
  * MIT License

--- a/yarn.lock
+++ b/yarn.lock
@@ -1588,6 +1588,11 @@ acorn@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
+add@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/add/-/add-2.0.6.tgz#248f0a9f6e5a528ef2295dbeec30532130ae2235"
+  integrity sha1-JI8Kn25aUo7yKV2+7DBTITCuIjU=
+
 ajv@^6.12.3:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
@@ -4685,10 +4690,10 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-maplibre-gl@^1.14.0:
-  version "1.14.0"
-  resolved "https://registry.yarnpkg.com/maplibre-gl/-/maplibre-gl-1.14.0.tgz#035663dae6cbaaca5b06024f6c5b51a42db1fc84"
-  integrity sha512-pqr/nsoZHx1rUY2Bpp0EFVcFVgrVOLkDDh2DhZcLVZVHYXdFOH/LyKUoLZda/3/CDTmlZy9ldJeZN8O0g1Ocpg==
+maplibre-gl@^1.15.0:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/maplibre-gl/-/maplibre-gl-1.15.0.tgz#6efa96b5fdda218390cb9db3eb1e901dc6ca9f51"
+  integrity sha512-C3Mq7HDTndvAs8w+Ai1QzvVdN7xG2+2iHjtp3Pkmk7tJeSMcqZzQYHKyOCBkpTs7g2P/aFqMU8Tg853RIZxIZg==
   dependencies:
     "@mapbox/geojson-rewind" "^0.5.0"
     "@mapbox/geojson-types" "^1.0.2"
@@ -7130,6 +7135,11 @@ yargs@^8.0.1:
     which-module "^2.0.0"
     y18n "^3.2.1"
     yargs-parser "^7.0.0"
+
+yarn@^1.22.10:
+  version "1.22.10"
+  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.10.tgz#c99daa06257c80f8fa2c3f1490724e394c26b18c"
+  integrity sha512-IanQGI9RRPAN87VGTF7zs2uxkSyQSrSPsju0COgbsKQOOXr5LtcVPeyXWgwVa0ywG3d8dg6kSYKGBuYK021qeA==
 
 yocto-queue@^0.1.0:
   version "0.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1588,11 +1588,6 @@ acorn@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
-add@^2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/add/-/add-2.0.6.tgz#248f0a9f6e5a528ef2295dbeec30532130ae2235"
-  integrity sha1-JI8Kn25aUo7yKV2+7DBTITCuIjU=
-
 ajv@^6.12.3:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
@@ -7135,11 +7130,6 @@ yargs@^8.0.1:
     which-module "^2.0.0"
     y18n "^3.2.1"
     yargs-parser "^7.0.0"
-
-yarn@^1.22.10:
-  version "1.22.10"
-  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.10.tgz#c99daa06257c80f8fa2c3f1490724e394c26b18c"
-  integrity sha512-IanQGI9RRPAN87VGTF7zs2uxkSyQSrSPsju0COgbsKQOOXr5LtcVPeyXWgwVa0ywG3d8dg6kSYKGBuYK021qeA==
 
 yocto-queue@^0.1.0:
   version "0.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4685,10 +4685,10 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-mapbox-gl@^1.13.1:
-  version "1.13.1"
-  resolved "https://registry.yarnpkg.com/mapbox-gl/-/mapbox-gl-1.13.1.tgz#322efe75ab4c764fc4c776da1506aad58d5a5b9d"
-  integrity sha512-GSyubcoSF5MyaP8z+DasLu5v7KmDK2pp4S5+VQ5WdVQUOaAqQY4jwl4JpcdNho3uWm2bIKs7x1l7q3ynGmW60g==
+maplibre-gl@^1.14.0:
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/maplibre-gl/-/maplibre-gl-1.14.0.tgz#035663dae6cbaaca5b06024f6c5b51a42db1fc84"
+  integrity sha512-pqr/nsoZHx1rUY2Bpp0EFVcFVgrVOLkDDh2DhZcLVZVHYXdFOH/LyKUoLZda/3/CDTmlZy9ldJeZN8O0g1Ocpg==
   dependencies:
     "@mapbox/geojson-rewind" "^0.5.0"
     "@mapbox/geojson-types" "^1.0.2"
@@ -4713,11 +4713,6 @@ mapbox-gl@^1.13.1:
     supercluster "^7.1.0"
     tinyqueue "^2.0.3"
     vt-pbf "^3.1.1"
-
-mapboxgl-spiderifier@^1.0.9:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/mapboxgl-spiderifier/-/mapboxgl-spiderifier-1.0.9.tgz#332d3f53eff9b4a0ea9e062dc480ddaae581f244"
-  integrity sha512-qox8WOWU9MGdH4IL8wtUO/inEyivCi44e4lYStJ9BXuTGU0t2TVdu6SsnStRNqnE67n0423FfCDXycGUj9XROA==
 
 mem@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-11406

As Mapbox GL JS v2 is no longer under a BSD-3-Clause license, this PR is switching to MapLibre GL JS, a community led fork derived from mapbox-gl-js prior to their switch to a non-OSS license: https://github.com/maplibre/maplibre-gl-js

Main changes: 
- Switch from mapbox-gl to maplibre-gl 
- Raname class names from "mapboxgl-" to "maplibregl-"
- Include mapboxgl-spiderifier code in repo and not as a dependency. 

The reason mapboxgl-spiderifier code was included directly in the repo is that the dependency requires mapbox-gl to display markers. The code was adapted to use markers from maplibre-gl instead. 

It was made a breaking change as the maps-app (and possibly other apps) uses the "mapboxgl-" class names.

After this PR the map controls display as before:

![Screenshot 2021-07-06 at 16 03 32](https://user-images.githubusercontent.com/548708/124613705-cef99300-de73-11eb-9940-d3568eface29.png)

The spiderify of events still works as before: 
![spiderify](https://user-images.githubusercontent.com/548708/124614779-e6854b80-de74-11eb-9231-9b9876961765.gif)