### PR TITLE
fix: symbol opacity

### DIFF
--- a/src/utils/opacity.js
+++ b/src/utils/opacity.js
@@ -7,7 +7,7 @@ const properties = {
     buffer: ['fill-opacity'],
     'buffer-outline': ['line-opacity'],
     label: ['text-opacity'],
-    icon: ['icon-opacity', 'text-opacity'],
+    symbol: ['icon-opacity', 'text-opacity'],
     cluster: ['circle-opacity', 'circle-stroke-opacity'],
     count: ['text-opacity'],
 }


### PR DESCRIPTION
Fixes a bug where it was not possible to change the opacity of image symbols: 

After this PR: 
![Screenshot 2021-09-10 at 11 08 20](https://user-images.githubusercontent.com/548708/132830042-f6815f58-88d1-4e8d-a472-50d81549a6b5.png)

Before: 
![Screenshot 2021-09-10 at 11 09 16](https://user-images.githubusercontent.com/548708/132830188-0ad09df3-34d8-4140-9257-4aaea6990b9c.png)
