### PR TITLE
fix: always open popup with single click

### DIFF
--- a/src/Map.js
+++ b/src/Map.js
@@ -341,11 +341,16 @@ export class MapGL extends Evented {
             this._popup = new Popup()
         }
 
+        // Remove previous attached onClose event before setting new content
+        this._popup.clear()
+
         this._popup
             .setLngLat(lnglat)
             .setDOMContent(content)
-            .onClose(onClose)
             .addTo(this)
+
+        // (Re)set onClose event
+        this._popup.onClose(onClose)
     }
 
     closePopup() {

--- a/src/ui/Popup.js
+++ b/src/ui/Popup.js
@@ -22,8 +22,18 @@ class Popup extends PopupGL {
         }
     }
 
+    // Remove onClose event if it exists
+    clear() {
+        if (this._onCloseFunc) {
+            this.off('close', this._onCloseFunc)
+            this._onCloseFunc = null
+        }
+        return this
+    }
+
     onClose(onClose) {
         if (typeof onClose === 'function') {
+            this._onCloseFunc = onClose
             this.on('close', onClose)
         }
         return this


### PR DESCRIPTION
This PR fixes an issue where it is not possible to open a new popup while another is open. You need to click twice, first to close the popup that is currently open, then to open a new one. 

The problem is that the mapping library is calling the onClose handler of the previous popup when a new popup is created, even though the same popup is reused. The fix is to detach the onClose handler when the popup is created, and then attach it again afterwards. 

After this PR opening popups are much quicker: 

![popup](https://user-images.githubusercontent.com/548708/132996140-7d59dcff-5b79-48c4-ba6a-d906b5394d1d.gif)

