### PR TITLE
fix: event stroke and count color

### DIFF
--- a/src/layers/ClientCluster.js
+++ b/src/layers/ClientCluster.js
@@ -1,7 +1,7 @@
 import Cluster from './Cluster'
 import { featureCollection } from '../utils/geometry'
 import { clusterLayer, clusterCountLayer } from '../utils/layers'
-import { eventStrokeColor as strokeColor } from '../utils/style'
+import { eventStrokeColor } from '../utils/style'
 
 class ClientCluster extends Cluster {
     createSource() {
@@ -13,7 +13,10 @@ class ClientCluster extends Cluster {
 
     createLayers() {
         const id = this.getId()
-        const { fillColor: color } = this.options
+        const {
+            fillColor: color,
+            strokeColor = eventStrokeColor,
+        } = this.options
 
         super.createLayers()
 

--- a/src/layers/ClientCluster.js
+++ b/src/layers/ClientCluster.js
@@ -1,7 +1,7 @@
 import Cluster from './Cluster'
 import { featureCollection } from '../utils/geometry'
 import { clusterLayer, clusterCountLayer } from '../utils/layers'
-import { eventStrokeColor } from '../utils/style'
+import { eventStrokeColor, clusterCountColor } from '../utils/style'
 
 class ClientCluster extends Cluster {
     createSource() {
@@ -16,13 +16,14 @@ class ClientCluster extends Cluster {
         const {
             fillColor: color,
             strokeColor = eventStrokeColor,
+            countColor = clusterCountColor,
         } = this.options
 
         super.createLayers()
 
         // Clusters
         this.addLayer(clusterLayer({ id, color, strokeColor }), true)
-        this.addLayer(clusterCountLayer({ id }))
+        this.addLayer(clusterCountLayer({ id, color: countColor }))
     }
 
     onAdd() {

--- a/src/layers/Cluster.js
+++ b/src/layers/Cluster.js
@@ -87,7 +87,7 @@ class Cluster extends Layer {
         this.addLayer(
             outlineLayer({
                 id,
-                color: eventStrokeColor,
+                color: strokeColor,
                 source: `${id}-polygons`,
             })
         )

--- a/src/layers/Events.js
+++ b/src/layers/Events.js
@@ -28,7 +28,7 @@ class Events extends Layer {
 
         this.addLayer(pointLayer({ id, color, radius, strokeColor }), true)
         this.addLayer(polygonLayer({ id, color }), true)
-        this.addLayer(outlineLayer({ id, color: eventStrokeColor }))
+        this.addLayer(outlineLayer({ id, color: strokeColor }))
     }
 }
 

--- a/src/layers/Events.js
+++ b/src/layers/Events.js
@@ -13,17 +13,20 @@ class Events extends Layer {
 
     createLayers() {
         const id = this.getId()
-        const { fillColor: color, radius, buffer, bufferStyle } = this.options
+        const {
+            fillColor: color,
+            strokeColor = eventStrokeColor,
+            radius,
+            buffer,
+            bufferStyle,
+        } = this.options
 
         if (buffer) {
             this.addLayer(bufferLayer({ id, ...bufferStyle }))
             this.addLayer(bufferOutlineLayer({ id, ...bufferStyle }))
         }
 
-        this.addLayer(
-            pointLayer({ id, color, radius, strokeColor: eventStrokeColor }),
-            true
-        )
+        this.addLayer(pointLayer({ id, color, radius, strokeColor }), true)
         this.addLayer(polygonLayer({ id, color }), true)
         this.addLayer(outlineLayer({ id, color: eventStrokeColor }))
     }

--- a/src/layers/ServerCluster.js
+++ b/src/layers/ServerCluster.js
@@ -10,7 +10,7 @@ import {
 } from '../utils/layers'
 import { isClusterPoint } from '../utils/filters'
 import { featureCollection } from '../utils/geometry'
-import { eventStrokeColor as strokeColor } from '../utils/style'
+import { eventStrokeColor, clusterCountColor } from '../utils/style'
 import { earthRadius } from '../utils/geo'
 
 class ServerCluster extends Cluster {
@@ -45,7 +45,12 @@ class ServerCluster extends Cluster {
 
     createLayers() {
         const id = this.getId()
-        const { fillColor: color, radius } = this.options
+        const {
+            fillColor: color,
+            strokeColor = eventStrokeColor,
+            countColor = clusterCountColor,
+            radius,
+        } = this.options
 
         // Non-clustered points
         this.addLayer(
@@ -65,7 +70,7 @@ class ServerCluster extends Cluster {
 
         // Clusters
         this.addLayer(clusterLayer({ id, color, strokeColor }), true)
-        this.addLayer(clusterCountLayer({ id }))
+        this.addLayer(clusterCountLayer({ id, color: countColor }))
     }
 
     getTileId(tile) {

--- a/src/utils/layers.js
+++ b/src/utils/layers.js
@@ -84,7 +84,7 @@ export const symbolLayer = ({ id, source, filter }) => ({
 })
 
 // Layer with cluster (circles)
-export const clusterLayer = ({ id, color }) => ({
+export const clusterLayer = ({ id, color, strokeColor }) => ({
     id: `${id}-cluster`,
     type: 'circle',
     source: id,
@@ -92,8 +92,8 @@ export const clusterLayer = ({ id, color }) => ({
     paint: {
         'circle-color': color,
         'circle-radius': clusterRadiusExpr,
+        'circle-stroke-color': strokeColor,
         'circle-stroke-width': defaults.strokeWidth,
-        'circle-stroke-color': defaults.eventStrokeColor,
     },
 })
 

--- a/src/utils/layers.js
+++ b/src/utils/layers.js
@@ -98,7 +98,7 @@ export const clusterLayer = ({ id, color, strokeColor }) => ({
 })
 
 //  Layer with cluster counts (text)
-export const clusterCountLayer = ({ id }) => ({
+export const clusterCountLayer = ({ id, color }) => ({
     id: `${id}-count`,
     type: 'symbol',
     source: id,
@@ -109,6 +109,6 @@ export const clusterCountLayer = ({ id }) => ({
         'text-size': defaults.textSize,
     },
     paint: {
-        'text-color': defaults.textColor,
+        'text-color': color || defaults.textColor,
     },
 })

--- a/src/utils/style.js
+++ b/src/utils/style.js
@@ -11,6 +11,7 @@ export const strokeWidth = 1
 export const hoverStrokeMultiplier = 3
 
 export const eventStrokeColor = '#333333'
+export const clusterCountColor = '#333333'
 
 export default {
     textFont,
@@ -22,4 +23,5 @@ export default {
     strokeWidth,
     hoverStrokeMultiplier,
     eventStrokeColor,
+    clusterCountColor,
 }

--- a/src/utils/style.js
+++ b/src/utils/style.js
@@ -11,7 +11,7 @@ export const strokeWidth = 1
 export const hoverStrokeMultiplier = 3
 
 export const eventStrokeColor = '#333333'
-export const clusterCountColor = '#333333'
+export const clusterCountColor = '#000000'
 
 export default {
     textFont,


### PR DESCRIPTION
This PR makes it possible to specify stroke and count color for event layers. It will make the events easier to separate and to see on different backgrounds. 

Most of the changes in this PR are linting fixes. 

After this PR: 

<img width="680" alt="Screenshot 2021-09-12 at 22 34 53" src="https://user-images.githubusercontent.com/548708/133002020-525d2970-3a8f-41f6-b0b2-c0dd47037f2c.png">

Before: 

<img width="678" alt="Screenshot 2021-09-12 at 22 36 18" src="https://user-images.githubusercontent.com/548708/133002031-f235c01e-0738-4f67-93ba-a00b451718b9.png">

After this PR: 

<img width="678" alt="Screenshot 2021-09-12 at 22 37 34" src="https://user-images.githubusercontent.com/548708/133002115-3208ec88-afa8-47ea-855c-2fd48aa7e1bb.png">

Before: 

<img width="678" alt="Screenshot 2021-09-12 at 22 38 09" src="https://user-images.githubusercontent.com/548708/133002119-5cfad88a-738d-47ec-b151-27d954f1b994.png">

After this PR: 

<img width="1019" alt="Screenshot 2021-09-13 at 09 47 41" src="https://user-images.githubusercontent.com/548708/133044429-17baf804-53ce-48b2-b9f6-a97049d04e26.png">

Before: 

<img width="1019" alt="Screenshot 2021-09-13 at 09 46 52" src="https://user-images.githubusercontent.com/548708/133044360-8ba87797-6b6f-4db8-a529-a62f60892d3f.png">
