### PR TITLE
fix: update donut clusters on source data (DHIS2-11923)

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@turf/length": "^6.3.0",
     "fetch-jsonp": "^1.1.3",
     "lodash.throttle": "^4.1.1",
-    "maplibre-gl": "^1.15.0",
+    "maplibre-gl": "^1.15.2",
     "polylabel": "^1.1.0",
     "suggestions": "^1.7.1",
     "uuid": "^8.3.2"

--- a/src/layers/DonutCluster.js
+++ b/src/layers/DonutCluster.js
@@ -51,12 +51,7 @@ class DonutCluster extends Cluster {
     }
 
     onSourceData = evt => {
-        if (
-            evt.sourceId === this.getId() &&
-            evt.isSourceLoaded &&
-            this.getSourceFeatures().length
-        ) {
-            this.getMapGL().off('sourcedata', this.onSourceData)
+        if (evt.sourceId === this.getId() && this.getSourceFeatures().length) {
             this.updateClusters()
         }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4685,10 +4685,10 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-maplibre-gl@^1.15.0:
-  version "1.15.0"
-  resolved "https://registry.yarnpkg.com/maplibre-gl/-/maplibre-gl-1.15.0.tgz#6efa96b5fdda218390cb9db3eb1e901dc6ca9f51"
-  integrity sha512-C3Mq7HDTndvAs8w+Ai1QzvVdN7xG2+2iHjtp3Pkmk7tJeSMcqZzQYHKyOCBkpTs7g2P/aFqMU8Tg853RIZxIZg==
+maplibre-gl@^1.15.2:
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/maplibre-gl/-/maplibre-gl-1.15.2.tgz#7fb47868b62455af916c090903f2154394450f9c"
+  integrity sha512-uPeV530apb4JfX3cRFfE+awFnbcJTOnCv2QvY4mw4huiInbybElWYkNzTs324YLSADq0f4bidRoYcR81ho3aLA==
   dependencies:
     "@mapbox/geojson-rewind" "^0.5.0"
     "@mapbox/geojson-types" "^1.0.2"


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-11923

This PR makes sure the donut clusters are updated when the layer data source is changed. Waiting for evt.isSourceLoaded is not reliable, and we keep the listener until the layer is removed. 

The maplibe-gl dependency is upgraded to latest 1.15.x version. 

After this PR all donut cluster are shown when the layer is loaded: 

<img width="900" alt="Screenshot 2021-10-04 at 15 15 26" src="https://user-images.githubusercontent.com/548708/135858035-9c67664c-b9b4-41b0-bc2a-97f638341436.png">

Before only the single events where displayed before map interaction: 

<img width="898" alt="Screenshot 2021-10-04 at 15 16 09" src="https://user-images.githubusercontent.com/548708/135858077-0b176415-b5e0-4297-8225-add95445330b.png">


