### PR TITLE
fix: use evaluate instead of getInfo to retrieve data from EE API

### DIFF
--- a/src/utils/earthengine.js
+++ b/src/utils/earthengine.js
@@ -4,10 +4,10 @@ const classAggregation = ['percentage', 'hectares', 'acres']
 
 export const hasClasses = type => classAggregation.includes(type)
 
-// Makes getInfo a promise
+// Makes evaluate a promise
 export const getInfo = instance =>
     new Promise((resolve, reject) =>
-        instance.getInfo((data, error) => {
+        instance.evaluate((data, error) => {
             if (error) {
                 reject(error)
             } else {


### PR DESCRIPTION
Issue: https://jira.dhis2.org/browse/DHIS2-12013

This PR uses `evaluate` to retrieve data from the Earth Engine API which is asynchronous by design:  https://developers.google.com/earth-engine/apidocs/ee-featurecollection-evaluate

We currently use `getInfo` which makes synchronous requests, although they should also be asynchronous when a callback is provided: https://developers.google.com/earth-engine/apidocs/ee-featurecollection-getinfo

This PR will not fix the main problem with unresponsive browser while waiting for data from EE API, but there seems to be a small improvement. 

I've kept the `getInfo` name as we are still testing different solutions, but only `evaluate` will be called with this PR. 