### PR TITLE
fix: include basemap when switching map style

### DIFF
--- a/src/layers/VectorStyle.js
+++ b/src/layers/VectorStyle.js
@@ -15,7 +15,12 @@ class VectorStyle extends Evented {
     async toggleVectorStyle(isOnMap, style, beforeId) {
         await this.removeOtherLayers()
         this._map.setBeforeLayerId(beforeId)
-        await this.setStyle(style)
+
+        // (Re)set map style if user is not switching to a new one
+        if (isOnMap || !this.mapHasVectorStyle()) {
+            await this.setStyle(style)
+        }
+
         this._isOnMap = isOnMap
         await this.addOtherLayers()
     }
@@ -66,6 +71,10 @@ class VectorStyle extends Evented {
                 await layer.removeFrom(this._map)
             }
         })
+    }
+
+    mapHasVectorStyle() {
+        return this._map.getLayers().some(layer => layer instanceof VectorStyle)
     }
 
     setIndex(index = BASEMAP_POSITION) {


### PR DESCRIPTION
When we switch fram vector style to a basemap before the vector style is done loading, the basemap is not shown on the map when we only add the overlays. 

This PR changes the behaviour so we add all layers that are not vector style instead. 