### PR TITLE
fix: don't update auth library for earth engine api

### DIFF
--- a/src/layers/EarthEngine.js
+++ b/src/layers/EarthEngine.js
@@ -95,6 +95,8 @@ class EarthEngine extends Layer {
                 accessToken
                     .then(token => {
                         const { access_token, client_id, expires_in } = token
+                        const extraScopes = null
+                        const callback = null
                         const updateAuthLibrary = false
 
                         data.setAuthToken(
@@ -102,8 +104,8 @@ class EarthEngine extends Layer {
                             tokenType,
                             access_token,
                             expires_in,
-                            null,
-                            null,
+                            extraScopes,
+                            callback,
                             updateAuthLibrary
                         )
 


### PR DESCRIPTION
JIRA issue: https://jira.dhis2.org/browse/DHIS2-12013

We don't need to update the Google authentication library when we set the token for the EE API. This small change will remove two Google requests.

After this PR: 

![Screenshot 2021-10-26 at 15 53 30](https://user-images.githubusercontent.com/548708/138893989-479344fc-05e2-4b5e-9864-e29325647e8f.png)

Before: 

![Screenshot 2021-10-26 at 15 57 17](https://user-images.githubusercontent.com/548708/138894110-c795d7e1-ca06-4c77-957f-fa4145e245ee.png)


