### PR TITLE
fix: only reference ee scale on the server

### DIFF
--- a/src/utils/earthengine.js
+++ b/src/utils/earthengine.js
@@ -32,12 +32,10 @@ export const combineReducers = ee => types =>
 
 // Returns the linear scale in meters of the units of this projection
 export const getScale = image =>
-    getInfo(
-        image
-            .select(0)
-            .projection()
-            .nominalScale()
-    )
+    image
+        .select(0)
+        .projection()
+        .nominalScale()
 
 // Returns visualisation params from legend
 export const getParamsFromLegend = legend => {


### PR DESCRIPTION
Improves: https://jira.dhis2.org/browse/DHIS2-12013

Small improvement that will speed up EE layers a bit. The image scale value is only used in server processing, and we don't need to get the value on the client side. 