### PR TITLE
fix: offline support (DHIS2-12212)

### DIFF
--- a/src/Map.js
+++ b/src/Map.js
@@ -287,8 +287,13 @@ export class MapGL extends Evented {
     onMouseOut = () => this.hideLabel()
 
     onError = evt => {
-        if (evt?.error?.message === 'Failed to fetch' && console?.error) {
-            console.error('Failed to fetch map data, are you offline?')
+        if (evt?.error?.message && console?.error) {
+            const { message } = evt.error
+            console.error(
+                message === 'Failed to fetch'
+                    ? 'Failed to fetch map data, are you offline?'
+                    : message
+            )
         }
     }
 

--- a/src/Map.js
+++ b/src/Map.js
@@ -28,11 +28,11 @@ export class MapGL extends Evented {
     constructor(el, options = {}) {
         super()
 
-        const { locale, ...opts } = options
+        const { locale, glyphs, ...opts } = options
 
         const mapgl = new Map({
             container: el,
-            style: mapStyle,
+            style: mapStyle({ glyphs }),
             maxZoom: 18,
             preserveDrawingBuffer: true, // TODO: requred for map download, but reduced performance
             attributionControl: false,
@@ -42,6 +42,7 @@ export class MapGL extends Evented {
         })
 
         this._mapgl = mapgl
+        this._glyphs = glyphs
 
         // Translate strings
         if (locale) {
@@ -58,6 +59,7 @@ export class MapGL extends Evented {
         mapgl.on('contextmenu', this.onContextMenu)
         mapgl.on('mousemove', this.onMouseMove)
         mapgl.on('mouseout', this.onMouseOut)
+        mapgl.on('error', this.onError)
 
         this._layers = []
         this._controls = {}
@@ -283,6 +285,12 @@ export class MapGL extends Evented {
     }
 
     onMouseOut = () => this.hideLabel()
+
+    onError = evt => {
+        if (evt?.error?.message === 'Failed to fetch' && console?.error) {
+            console.error('Failed to fetch map data, are you offline?')
+        }
+    }
 
     // Returns the map zoom level
     getZoom() {

--- a/src/Map.js
+++ b/src/Map.js
@@ -146,6 +146,7 @@ export class MapGL extends Evented {
         mapgl.off('contextmenu', this.onContextMenu)
         mapgl.off('mousemove', this.onMouseMove)
         mapgl.off('mouseout', this.onMouseOut)
+        mapgl.off('error', this.onError)
 
         mapgl.remove()
 

--- a/src/layers/LayerGroup.js
+++ b/src/layers/LayerGroup.js
@@ -78,8 +78,8 @@ class LayerGroup extends Evented {
         return this._isVisible
     }
 
-    moveToTop() {
-        this._layers.forEach(layer => layer.moveToTop())
+    move() {
+        this._layers.forEach(layer => layer.move())
     }
 
     hasLayerId(id) {

--- a/src/layers/VectorStyle.js
+++ b/src/layers/VectorStyle.js
@@ -36,7 +36,8 @@ class VectorStyle extends Evented {
 
     // Remove vector style from map, reset to default map style
     async removeFrom() {
-        await this.toggleVectorStyle(false, mapStyle)
+        const glyphs = this._map._glyphs
+        await this.toggleVectorStyle(false, mapStyle({ glyphs }))
     }
 
     // Set map style, resolves promise when map is ready for other layers

--- a/src/utils/style.js
+++ b/src/utils/style.js
@@ -13,12 +13,14 @@ export const hoverStrokeMultiplier = 3
 export const eventStrokeColor = '#333333'
 export const clusterCountColor = '#000000'
 
-export const mapStyle = {
+export const mapStyle = ({
+    glyphs = 'https://fonts.openmaptiles.org/{fontstack}/{range}.pbf',
+}) => ({
     version: 8,
     sources: {},
     layers: [],
-    glyphs: 'https://fonts.openmaptiles.org/{fontstack}/{range}.pbf', // TODO: Host ourseleves
-}
+    glyphs,
+})
 
 export default {
     textFont,

--- a/src/utils/style.js
+++ b/src/utils/style.js
@@ -13,9 +13,10 @@ export const hoverStrokeMultiplier = 3
 export const eventStrokeColor = '#333333'
 export const clusterCountColor = '#000000'
 
-export const mapStyle = ({
-    glyphs = 'https://fonts.openmaptiles.org/{fontstack}/{range}.pbf',
-}) => ({
+export const defaultGlyphs =
+    'https://fonts.openmaptiles.org/{fontstack}/{range}.pbf'
+
+export const mapStyle = ({ glyphs = defaultGlyphs }) => ({
     version: 8,
     sources: {},
     layers: [],


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-12212

This PR will add offline support to `maps-gl`. It adds support for WebGL fonts hosted locally, and the app using this lib will not break if there is an error. The error will still be displayed in the console. One error could be failure of loading map tiles from an external source. 

Map created offline with errors on the console due to failure of loading basemap tiles:
![Screenshot 2021-12-01 at 14 20 51](https://user-images.githubusercontent.com/548708/144241981-f7039b80-5680-4493-8ad2-06365704a345.png)

The PR also fixes a bug in layerGroup.js where "moveToTop" method is changed to the more flexible "move" method. 