### PR TITLE
fix: don't use optional chaining in maps-gl

### DIFF
--- a/src/Map.js
+++ b/src/Map.js
@@ -288,7 +288,8 @@ export class MapGL extends Evented {
     onMouseOut = () => this.hideLabel()
 
     onError = evt => {
-        if (evt?.error?.message && console?.error) {
+        // TODO: Use optional chaining when DHIS2 Maps 2.35 is not supported
+        if (evt && evt.error && evt.error.message && console && console.error) {
             const { message } = evt.error
             console.error(
                 message === 'Failed to fetch'


### PR DESCRIPTION
DHIS2 Maps 2.35 uses an old webpack/babel setup and it was difficult to get optional chaining to work without a bigger upgrade. I suggest that we don't use optional chaining in maps-gl before the apps using it supports it. 