### PR TITLE
Aggregate values for each band/age group (DHIS2-11039)

### DIFF
--- a/src/earthengine/ee_worker.js
+++ b/src/earthengine/ee_worker.js
@@ -244,6 +244,8 @@ class EarthEngineWorker {
             if (useHistogram) {
                 // Used for landcover
                 const reducer = ee.Reducer.frequencyHistogram()
+                const scaleValue = await getInfo(scale)
+
                 return getInfo(
                     image
                         .reduceRegions(collection, reducer, scale)
@@ -251,7 +253,7 @@ class EarthEngineWorker {
                 ).then(data =>
                     getHistogramStatistics({
                         data,
-                        scale,
+                        scale: scaleValue,
                         aggregationType,
                         legend,
                     })

--- a/src/earthengine/ee_worker.js
+++ b/src/earthengine/ee_worker.js
@@ -275,7 +275,11 @@ class EarthEngineWorker {
 
                     band.forEach(band =>
                         aggregationType.forEach(type =>
-                            props.push(`${band}_${type}`)
+                            props.push(
+                                aggregationType.length === 1
+                                    ? band
+                                    : `${band}_${type}`
+                            )
                         )
                     )
                 }


### PR DESCRIPTION
Fixes in maps-gl: https://jira.dhis2.org/browse/DHIS2-11039

This PR will be merged to the EE web worker refactor PR.

This PR will aggregate values for each image band, in addition to all bands combined. We use bands for age/gender groups for population layer. It means that we aggregate values for each age/gender group in addition to all selected groups combined. 

After this PR we return aggregations for each band/group:

```
{
  M_0_mean: 0.5269629912153082, 
  M_0_sum: 9606.035231643797,
  M_1_mean: 1.9892161725946027,
  M_1_sum: 36261.52302124757,
  M_5_mean: 2.277558791314017,
  M_5_sum: 41517.735317703555,
  mean: 4.793737955123928,
  sum: 87385.29357059492,
}
```

Before we only return for all bands/groups combined:

```
{
  mean: 4.793737955123928,
  sum: 87385.29357059492,
}
```

There will be another PR in maps-app, where most of the work is done. 