### PR TITLE
fix: only preload earth engine aggregations if org units are passed (DHIS2-12276)

### DIFF
--- a/src/layers/EarthEngine.js
+++ b/src/layers/EarthEngine.js
@@ -36,6 +36,8 @@ class EarthEngine extends Layer {
 
                             const { preload, data } = this.options
 
+                            // Get aggregations if not plugin (preload=false) and org units
+                            // are passed (data not undefined)
                             if (preload && data) {
                                 this.getAggregations()
                             }

--- a/src/layers/EarthEngine.js
+++ b/src/layers/EarthEngine.js
@@ -34,7 +34,9 @@ class EarthEngine extends Layer {
                             super.addTo(map)
                             this.onLoad()
 
-                            if (this.options.preload) {
+                            const { preload, data } = this.options
+
+                            if (preload && data) {
                                 this.getAggregations()
                             }
                         }

--- a/src/layers/ServerCluster.js
+++ b/src/layers/ServerCluster.js
@@ -206,7 +206,9 @@ class ServerCluster extends Cluster {
 
     getSourceCacheTiles = () => {
         const mapgl = this._map.getMapGL()
-        return Object.values(mapgl.style.sourceCaches[this.getId()]._tiles)
+        const sourceCache = mapgl.style.sourceCaches[this.getId()]
+
+        return sourceCache ? Object.values(sourceCache._tiles) : []
     }
 
     // Called by parent class


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-12276

This PR adds a check so earth engine aggregations are only calculated if `preload=true` is passed (when the layer is added from DHIS2 Maps, and not on the dashboard) + org units are passed in the `data` option (as they are used for aggregations). This avoids an uncaught error in the console: "Missing org unit features". 

The PR also includes an additional check if tiles are cached before trying to return them for server cluster layer. I have not been able to reproduce this issue locally. It could be related to the uncaught error above as it was reported when server cluster layer was combined with an EE layer. 