### PR TITLE
fix: use shared worker for Earth Engine layers

### DIFF
--- a/src/earthengine/ee_worker.js
+++ b/src/earthengine/ee_worker.js
@@ -294,4 +294,9 @@ class EarthEngineWorker {
     }
 }
 
-onconnect = evt => expose(EarthEngineWorker, evt.ports[0])
+// Service Worker not supported in Safari
+if (typeof ServiceWorker !== 'undefined') {
+    onconnect = evt => expose(EarthEngineWorker, evt.ports[0])
+} else {
+    expose(EarthEngineWorker)
+}

--- a/src/earthengine/ee_worker.js
+++ b/src/earthengine/ee_worker.js
@@ -295,7 +295,7 @@ class EarthEngineWorker {
 }
 
 // Service Worker not supported in Safari
-if (typeof ServiceWorker !== 'undefined') {
+if (typeof onconnect !== 'undefined') {
     onconnect = evt => expose(EarthEngineWorker, evt.ports[0])
 } else {
     expose(EarthEngineWorker)

--- a/src/earthengine/ee_worker.js
+++ b/src/earthengine/ee_worker.js
@@ -294,4 +294,4 @@ class EarthEngineWorker {
     }
 }
 
-expose(EarthEngineWorker)
+onconnect = evt => expose(EarthEngineWorker, evt.ports[0])

--- a/src/earthengine/ee_worker_loader.js
+++ b/src/earthengine/ee_worker_loader.js
@@ -8,10 +8,21 @@ const getEarthEngineWorker = getAuthToken =>
         if (resolvedWorker) {
             resolve(resolvedWorker)
         } else {
+            // Service Worker not supported in Safari
             const EarthEngineWorker = wrap(
-                new SharedWorker(
-                    new URL('../earthengine/ee_worker.js', import.meta.url)
-                ).port
+                typeof ServiceWorker !== 'undefined'
+                    ? new SharedWorker(
+                          new URL(
+                              '../earthengine/ee_worker.js',
+                              import.meta.url
+                          )
+                      ).port
+                    : new Worker(
+                          new URL(
+                              '../earthengine/ee_worker.js',
+                              import.meta.url
+                          )
+                      )
             )
 
             EarthEngineWorker.setAuthToken(proxy(getAuthToken))

--- a/src/earthengine/ee_worker_loader.js
+++ b/src/earthengine/ee_worker_loader.js
@@ -10,7 +10,7 @@ const getEarthEngineWorker = getAuthToken =>
         } else {
             // Service Worker not supported in Safari
             const EarthEngineWorker = wrap(
-                typeof ServiceWorker !== 'undefined'
+                typeof SharedWorker !== 'undefined'
                     ? new SharedWorker(
                           new URL(
                               '../earthengine/ee_worker.js',

--- a/src/earthengine/ee_worker_loader.js
+++ b/src/earthengine/ee_worker_loader.js
@@ -9,9 +9,9 @@ const getEarthEngineWorker = getAuthToken =>
             resolve(resolvedWorker)
         } else {
             const EarthEngineWorker = wrap(
-                new Worker(
+                new SharedWorker(
                     new URL('../earthengine/ee_worker.js', import.meta.url)
-                )
+                ).port
             )
 
             EarthEngineWorker.setAuthToken(proxy(getAuthToken))


### PR DESCRIPTION
This PR will use shared worker for Earth Engine layers. 

Currently on dashboard, a worker is created for each map with an Earth Engine layer (20.bundle.js): 

<img width="348" alt="Screenshot 2022-01-04 at 14 35 00" src="https://user-images.githubusercontent.com/548708/148067528-d2d88239-9ab5-4814-87d8-1eea00ceb439.png">

With this PR we can check if the same worker is reused - also between dashboards. 

To inspect the shared worker, use: chrome://inspect/#workers

Confirmation that the shared worker operate as before: 

<img width="1106" alt="Screenshot 2022-01-04 at 14 42 50" src="https://user-images.githubusercontent.com/548708/148067952-0ecb8392-d07b-43f3-b434-4f19cabd0741.png">

Added a fallback to Web Worker in Safari (Shared Worker not supported): 

<img width="1167" alt="Screenshot 2022-01-04 at 15 48 23" src="https://user-images.githubusercontent.com/548708/148076943-88a5295b-fdef-4976-9ae4-07bd37eca3cd.png">

Before the fallback was added: 

<img width="963" alt="Screenshot 2022-01-04 at 14 59 22" src="https://user-images.githubusercontent.com/548708/148077003-e1023683-bdf2-4eb9-bffb-76a6029affe8.png">

About Comlink and Shared Worker: https://github.com/GoogleChromeLabs/comlink#sharedworker
