### PR TITLE
fix: keep data filter when Earth Engine layer is redrawn (DHIS2-12502)

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@turf/length": "^6.3.0",
     "comlink": "^4.3.1",
     "fetch-jsonp": "^1.1.3",
-    "lodash.throttle": "^4.1.1",
+    "lodash": "^4.17.21",
     "maplibre-gl": "^1.15.2",
     "polylabel": "^1.1.0",
     "suggestions": "^1.7.1",

--- a/src/layers/DonutCluster.js
+++ b/src/layers/DonutCluster.js
@@ -1,4 +1,4 @@
-import throttle from 'lodash.throttle'
+import { throttle } from 'lodash'
 import Cluster from './Cluster'
 import DonutMarker from './DonutMarker'
 import { featureCollection } from '../utils/geometry'

--- a/src/layers/EarthEngine.js
+++ b/src/layers/EarthEngine.js
@@ -85,7 +85,7 @@ class EarthEngine extends Layer {
         if (this.options.data) {
             this.setSource(id, {
                 type: 'geojson',
-                data: featureCollection(this.getFeatures()),
+                data: featureCollection(this.getFilteredFeatures()),
             })
         }
     }
@@ -189,8 +189,9 @@ class EarthEngine extends Layer {
     }
 
     // Returns filtered features based on string ids
-    getFilteredFeatures(ids) {
+    getFilteredFeatures() {
         const features = this.getFeatures()
+        const ids = this._filteredFeatureIds
 
         return Array.isArray(ids)
             ? features.filter(f => ids.includes(f.properties.id))
@@ -199,10 +200,12 @@ class EarthEngine extends Layer {
 
     // Filter the org units features shown
     filter(ids) {
+        this._filteredFeatureIds = ids
+
         const source = this.getMapGL().getSource(this.getId())
 
         if (source) {
-            source.setData(featureCollection(this.getFilteredFeatures(ids)))
+            source.setData(featureCollection(this.getFilteredFeatures()))
         }
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4589,11 +4589,6 @@ lodash.templatesettings@^4.0.0:
   dependencies:
     lodash._reinterpolate "^3.0.0"
 
-lodash.throttle@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
-  integrity sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=
-
 lodash@4.17.11:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
@@ -4603,6 +4598,11 @@ lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.2.1:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
+
+lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 loud-rejection@^1.0.0:
   version "1.6.0"


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-12502

This PR makes sure the layer filter (which org units to show) is kept when Earth Engine layers are redrawn. This happens when the user is switching from/to a vector style basemap. 