### PR TITLE
fix: handle ee null values

### DIFF
--- a/src/layers/EarthEngine.js
+++ b/src/layers/EarthEngine.js
@@ -5,6 +5,7 @@ import { isPoint, featureCollection } from '../utils/geometry'
 import { getBufferGeometry } from '../utils/buffers'
 import { polygonLayer, outlineLayer, pointLayer } from '../utils/layers'
 import { setPrecision } from '../utils/numbers'
+import { setTemplate } from '../utils/core'
 
 class EarthEngine extends Layer {
     constructor(options) {
@@ -154,14 +155,19 @@ class EarthEngine extends Layer {
     showValue = latlng =>
         this.getValue(latlng).then(value => {
             const { lng, lat } = latlng
-            const options = {
-                ...this.options,
-                value: typeof value === 'number' ? setPrecision(value) : value,
+            const options = this.options
+            let content
+
+            if (value === null) {
+                content = setTemplate(options.nullPopup, options)
+                console.log('content', content)
+            } else {
+                content = setTemplate(options.popup, {
+                    ...options,
+                    value:
+                        typeof value === 'number' ? setPrecision(value) : value,
+                })
             }
-            const content = options.popup.replace(
-                /\{ *([\w_-]+) *\}/g,
-                (str, key) => options[key]
-            )
 
             this._map.openPopup(document.createTextNode(content), [lng, lat])
         })

--- a/src/layers/EarthEngine.js
+++ b/src/layers/EarthEngine.js
@@ -160,7 +160,6 @@ class EarthEngine extends Layer {
 
             if (value === null) {
                 content = setTemplate(options.nullPopup, options)
-                console.log('content', content)
             } else {
                 content = setTemplate(options.popup, {
                     ...options,

--- a/src/utils/__tests__/core.spec.js
+++ b/src/utils/__tests__/core.spec.js
@@ -1,0 +1,13 @@
+import { setTemplate } from '../core'
+
+describe('core utils', () => {
+    it('Should add values to a template string', () => {
+        expect(
+            setTemplate('{name}: {value} {unit}', {
+                name: 'Population',
+                value: 123,
+                unit: 'per hectare',
+            })
+        ).toBe('Population: 123 per hectare')
+    })
+})

--- a/src/utils/__tests__/core.spec.js
+++ b/src/utils/__tests__/core.spec.js
@@ -1,7 +1,7 @@
 import { setTemplate } from '../core'
 
 describe('core utils', () => {
-    it('Should add values to a template string', () => {
+    it('Should add values to template string', () => {
         expect(
             setTemplate('{name}: {value} {unit}', {
                 name: 'Population',

--- a/src/utils/__tests__/core.spec.js
+++ b/src/utils/__tests__/core.spec.js
@@ -9,5 +9,12 @@ describe('core utils', () => {
                 unit: 'per hectare',
             })
         ).toBe('Population: 123 per hectare')
+
+        expect(
+            setTemplate('{name}: {noValue}', {
+                name: 'Population',
+                noValue: 'no value',
+            })
+        ).toBe('Population: no value')
     })
 })

--- a/src/utils/__tests__/geometry.spec.js
+++ b/src/utils/__tests__/geometry.spec.js
@@ -24,7 +24,7 @@ const polygon = {
     },
 }
 
-describe('numbers', () => {
+describe('geometry', () => {
     it('Should return true if a feature has point geometry', () => {
         expect(isPoint(point)).toBe(true)
         expect(isPoint(polygon)).toBe(false)

--- a/src/utils/core.js
+++ b/src/utils/core.js
@@ -1,3 +1,3 @@
-// Replaces {xxx} with data in a string template
+// Replaces {key} with data in a string template
 export const setTemplate = (text, data) =>
     text.replace(/\{ *([\w_-]+) *\}/g, (str, key) => data[key])

--- a/src/utils/core.js
+++ b/src/utils/core.js
@@ -1,0 +1,3 @@
+// Replaces {xxx} with data in a string template
+export const setTemplate = (text, data) =>
+    text.replace(/\{ *([\w_-]+) *\}/g, (str, key) => data[key])

--- a/src/utils/earthengine.js
+++ b/src/utils/earthengine.js
@@ -1,6 +1,8 @@
 export const defaultOptions = {
     bandReducer: 'sum',
     popup: '{name}: {value} {unit}',
+    nullPopup: '{name}: {noValue}',
+    noValue: 'no value',
 }
 
 const workerOptions = [


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-12506

This PR includes better null value handling for Earth Engine layers.

Before this layer if you right-click an area with no data: 

![Screenshot 2022-01-24 at 17 16 28](https://user-images.githubusercontent.com/548708/150832936-b4f311ce-5202-4b07-816d-ae78a2010a65.png)

After this PR: 
![Screenshot 2022-01-24 at 18 19 05](https://user-images.githubusercontent.com/548708/150832967-87dfa12a-9685-43f5-b668-3f1fa91d4d09.png)

When there is a value, it will still show like this:
![Screenshot 2022-01-24 at 18 19 16](https://user-images.githubusercontent.com/548708/150833055-237e3814-5cab-4766-af5b-b6bf51f99194.png)

Related maps app PR to get "no value" translated: https://github.com/dhis2/maps-app/pull/2017

The long-term plan is to move the popup handling to the Maps app. 
 