### PR TITLE
fix: make sure map is present before removing layers and source (DHIS2-12583)

### DIFF
--- a/src/layers/Layer.js
+++ b/src/layers/Layer.js
@@ -79,17 +79,19 @@ class Layer extends Evented {
 
         this.onRemove()
 
-        layers.forEach(layer => {
-            if (mapgl.getLayer(layer.id)) {
-                mapgl.removeLayer(layer.id)
-            }
-        })
+        if (mapgl) {
+            layers.forEach(layer => {
+                if (mapgl.getLayer(layer.id)) {
+                    mapgl.removeLayer(layer.id)
+                }
+            })
 
-        Object.keys(source).forEach(id => {
-            if (mapgl.getSource(id)) {
-                mapgl.removeSource(id)
-            }
-        })
+            Object.keys(source).forEach(id => {
+                if (mapgl.getSource(id)) {
+                    mapgl.removeSource(id)
+                }
+            })
+        }
 
         if (onClick) {
             this.off('click', onClick)

--- a/src/layers/VectorStyle.js
+++ b/src/layers/VectorStyle.js
@@ -37,7 +37,9 @@ class VectorStyle extends Evented {
     // Remove vector style from map, reset to default map style
     async removeFrom() {
         const glyphs = this._map._glyphs
-        await this.toggleVectorStyle(false, mapStyle({ glyphs }))
+        if (this._map.getMapGL()) {
+            await this.toggleVectorStyle(false, mapStyle({ glyphs }))
+        }
     }
 
     // Set map style, resolves promise when map is ready for other layers


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-12583

This PR fixes an issue when maps a added to a dashboard and a filter is changed. The maps are removed and added again, and we have added a check if the map instance is still present before removing layers or source.  