### PR TITLE
chore: allow multiple layer options

### DIFF
--- a/src/layers/Boundary.js
+++ b/src/layers/Boundary.js
@@ -28,6 +28,7 @@ class Boundary extends Layer {
     createLayers() {
         const id = this.getId()
         const { label, labelStyle } = this.options
+        const isInteractive = true
 
         // Line layer
         this.addLayer(
@@ -46,7 +47,7 @@ class Boundary extends Layer {
                 },
                 filter: ['==', '$type', 'Polygon'],
             },
-            true
+            { isInteractive }
         )
 
         // Point layer
@@ -68,7 +69,7 @@ class Boundary extends Layer {
                 },
                 filter: ['==', '$type', 'Point'],
             },
-            true
+            { isInteractive }
         )
 
         if (label) {

--- a/src/layers/Choropleth.js
+++ b/src/layers/Choropleth.js
@@ -13,10 +13,11 @@ class Choropleth extends Layer {
     createLayers() {
         const id = this.getId()
         const { color, label, labelStyle } = this.options
+        const isInteractive = true
 
-        this.addLayer(polygonLayer({ id, color }), true)
+        this.addLayer(polygonLayer({ id, color }), { isInteractive })
         this.addLayer(outlineLayer({ id }))
-        this.addLayer(pointLayer({ id, color }), true)
+        this.addLayer(pointLayer({ id, color }), { isInteractive })
 
         if (label) {
             this.addLayer(labelLayer({ id, label, ...labelStyle }))

--- a/src/layers/ClientCluster.js
+++ b/src/layers/ClientCluster.js
@@ -18,11 +18,14 @@ class ClientCluster extends Cluster {
             strokeColor = eventStrokeColor,
             countColor = clusterCountColor,
         } = this.options
+        const isInteractive = true
 
         super.createLayers()
 
         // Clusters
-        this.addLayer(clusterLayer({ id, color, strokeColor }), true)
+        this.addLayer(clusterLayer({ id, color, strokeColor }), {
+            isInteractive,
+        })
         this.addLayer(clusterCountLayer({ id, color: countColor }))
     }
 

--- a/src/layers/Cluster.js
+++ b/src/layers/Cluster.js
@@ -66,6 +66,7 @@ class Cluster extends Layer {
             strokeColor = eventStrokeColor,
             radius,
         } = this.options
+        const isInteractive = true
 
         // Non-clustered points
         this.addLayer(
@@ -76,14 +77,13 @@ class Cluster extends Layer {
                 radius,
                 filter: isClusterPoint,
             }),
-            true
+            { isInteractive }
         )
 
         // Non-clustered polygons
-        this.addLayer(
-            polygonLayer({ id, color, source: `${id}-polygons` }),
-            true
-        )
+        this.addLayer(polygonLayer({ id, color, source: `${id}-polygons` }), {
+            isInteractive,
+        })
         this.addLayer(
             outlineLayer({
                 id,

--- a/src/layers/EarthEngine.js
+++ b/src/layers/EarthEngine.js
@@ -95,6 +95,7 @@ class EarthEngine extends Layer {
     createLayers() {
         const id = this.getId()
         const source = id
+        const isInteractive = true
 
         this.addLayer({
             id: `${id}-raster`,
@@ -103,7 +104,9 @@ class EarthEngine extends Layer {
         })
 
         if (this.options.data) {
-            this.addLayer(polygonLayer({ id, source, opacity: 0.9 }), true)
+            this.addLayer(polygonLayer({ id, source, opacity: 0.9 }), {
+                isInteractive,
+            })
             this.addLayer(outlineLayer({ id, source }))
             this.addLayer(
                 pointLayer({

--- a/src/layers/Events.js
+++ b/src/layers/Events.js
@@ -20,14 +20,17 @@ class Events extends Layer {
             buffer,
             bufferStyle,
         } = this.options
+        const isInteractive = true
 
         if (buffer) {
             this.addLayer(bufferLayer({ id, ...bufferStyle }))
             this.addLayer(bufferOutlineLayer({ id, ...bufferStyle }))
         }
 
-        this.addLayer(pointLayer({ id, color, radius, strokeColor }), true)
-        this.addLayer(polygonLayer({ id, color }), true)
+        this.addLayer(pointLayer({ id, color, radius, strokeColor }), {
+            isInteractive,
+        })
+        this.addLayer(polygonLayer({ id, color }), { isInteractive })
         this.addLayer(outlineLayer({ id, color: strokeColor }))
     }
 }

--- a/src/layers/GeoJson.js
+++ b/src/layers/GeoJson.js
@@ -28,20 +28,26 @@ class GeoJson extends Layer {
             labelStyle,
         } = this.options
         const { radius, color, strokeColor, weight: width } = style
+        const isInteractive = true
 
         if (buffer) {
             this.addLayer(bufferLayer({ id, ...bufferStyle }))
             this.addLayer(bufferOutlineLayer({ id, ...bufferStyle }))
         }
 
-        this.addLayer(polygonLayer({ id, color }), true)
+        this.addLayer(polygonLayer({ id, color }), {
+            isInteractive,
+        })
         this.addLayer(outlineLayer({ id, color: strokeColor, width }))
-        this.addLayer(lineLayer({ id, color, width }), true)
-        this.addLayer(
-            pointLayer({ id, color, strokeColor, width, radius }),
-            true
-        )
-        this.addLayer(symbolLayer({ id }), true)
+        this.addLayer(lineLayer({ id, color, width }), {
+            isInteractive,
+        })
+        this.addLayer(pointLayer({ id, color, strokeColor, width, radius }), {
+            isInteractive,
+        })
+        this.addLayer(symbolLayer({ id }), {
+            isInteractive,
+        })
 
         if (label) {
             this.addLayer(labelLayer({ id, label, ...labelStyle }))

--- a/src/layers/Layer.js
+++ b/src/layers/Layer.js
@@ -187,7 +187,9 @@ class Layer extends Evented {
         return this.isInteractive() ? this._interactiveIds : []
     }
 
-    addLayer(layer, isInteractive) {
+    addLayer(layer, layerOptions = {}) {
+        const { isInteractive } = layerOptions
+
         this._layers.push(layer)
 
         if (isInteractive) {

--- a/src/layers/Markers.js
+++ b/src/layers/Markers.js
@@ -15,13 +15,14 @@ class Markers extends Layer {
     createLayer() {
         const id = this.getId()
         const { buffer, bufferStyle, label, labelStyle } = this.options
+        const isInteractive = true
 
         if (buffer) {
             this.addLayer(bufferLayer({ id, ...bufferStyle }))
             this.addLayer(bufferOutlineLayer({ id, ...bufferStyle }))
         }
 
-        this.addLayer(symbolLayer({ id }), true)
+        this.addLayer(symbolLayer({ id }), { isInteractive })
 
         if (label) {
             this.addLayer(labelLayer({ id, label, ...labelStyle }))

--- a/src/layers/ServerCluster.js
+++ b/src/layers/ServerCluster.js
@@ -51,6 +51,7 @@ class ServerCluster extends Cluster {
             countColor = clusterCountColor,
             radius,
         } = this.options
+        const isInteractive = true
 
         // Non-clustered points
         this.addLayer(
@@ -61,15 +62,17 @@ class ServerCluster extends Cluster {
                 radius,
                 filter: isClusterPoint,
             }),
-            true
+            { isInteractive }
         )
 
         // Non-clustered polygons
-        this.addLayer(polygonLayer({ id, color }), true)
+        this.addLayer(polygonLayer({ id, color }), { isInteractive })
         this.addLayer(outlineLayer({ id, color: strokeColor }))
 
         // Clusters
-        this.addLayer(clusterLayer({ id, color, strokeColor }), true)
+        this.addLayer(clusterLayer({ id, color, strokeColor }), {
+            isInteractive,
+        })
         this.addLayer(clusterCountLayer({ id, color: countColor }))
     }
 

--- a/src/layers/__tests__/Layer.spec.js
+++ b/src/layers/__tests__/Layer.spec.js
@@ -63,7 +63,7 @@ describe('Layer', () => {
         const mockMapLayer = { id: 42 }
 
         layer.addTo(mockMap)
-        layer.addLayer(mockMapLayer, true)
+        layer.addLayer(mockMapLayer, { isInteractive: true })
 
         expect(layer.getLayers()).toHaveLength(1)
         expect(layer.getLayers()[0].id).toBe(mockMapLayer.id)


### PR DESCRIPTION
This PR in an internal refactor to support multiple layer options. Before this PR we pass "isInteractive" as a boolean argument if the map layer should be interactive. In https://jira.dhis2.org/browse/DHIS2-11969 we need another layer option. With this PR layer options is an object where we easily can add new options when we need them. This should also make the code easier to understand. 
