### PR TITLE
fix: redraw layer group when map style change

### DIFF
--- a/src/layers/LayerGroup.js
+++ b/src/layers/LayerGroup.js
@@ -8,30 +8,34 @@ class LayerGroup extends Evented {
         this.options = options || {}
         this._layers = []
         this._layerConfigs = []
+        this._isVisible = true
+    }
+
+    createLayer() {
+        this._layerConfigs.forEach(config =>
+            this._layers.push(this._map.createLayer(config))
+        )
+
+        if (this.options.opacity) {
+            this.setOpacity(this.options.opacity)
+        }
     }
 
     addTo(map) {
         this._map = map
-        const { opacity } = this.options
 
-        this._layerConfigs.forEach(config => {
-            const layer = this._map.createLayer({
-                opacity,
-                ...config,
-            })
+        if (!this._layers.length) {
+            this.createLayer()
+        }
 
-            layer.addTo(map)
-
-            this._layers.push(layer)
-        })
+        this._layers.forEach(layer => layer.addTo(map))
 
         this.on('contextmenu', this.onContextMenu)
     }
 
     removeFrom(map) {
         this._layers.forEach(layer => layer.removeFrom(map))
-        this._layers = []
-        this._layerConfigs = []
+        this.off('contextmenu', this.onContextMenu)
     }
 
     addLayer(config) {


### PR DESCRIPTION
This PR fixes a remaining issue from the vector style support: when the user is switching from/to a vector style we need to make sure that the layer is properly redrawn. With this PR, the layers within a layer group are only created once, and then they are removed and added to the map every time the user is switching to/from a vector style. 

Before the this PR a layer group (used for TEI layers) will not show when the user is switching to/from a vector style:
<img width="1131" alt="Screenshot 2022-02-07 at 17 10 57" src="https://user-images.githubusercontent.com/548708/152827964-3bb2b009-9ae0-49ca-adfb-8922ee67900b.png">

After this PR the layer group is properly redrawn: 
<img width="1131" alt="Screenshot 2022-02-07 at 17 12 55" src="https://user-images.githubusercontent.com/548708/152828045-e979aa00-9b43-4ded-a726-78e24dce713c.png">
