### PR TITLE
fix: hide label on mouse move

### DIFF
--- a/src/layers/Layer.js
+++ b/src/layers/Layer.js
@@ -339,9 +339,10 @@ class Layer extends Evented {
                 /\{ *([\w_-]+) *\}/g,
                 (str, key) => properties[key] || ''
             )
-            const { lngLat, point } = evt
 
-            this._map.showLabel(content, lngLat)
+            this._map.showLabel(content, evt.lngLat)
+        } else {
+            this._map.hideLabel()
         }
     }
 }


### PR DESCRIPTION
This PR will make sure the mouseover label is hidden when the user moves the cursor over an area where there is no label assigned. The fix is needed for an upcoming feature: https://jira.dhis2.org/browse/DHIS2-11969