### PR TITLE
fix: check if map still exists before collapsing a cluster (DHIS2-12583)

### DIFF
--- a/src/layers/Cluster.js
+++ b/src/layers/Cluster.js
@@ -131,9 +131,11 @@ class Cluster extends Layer {
     }
 
     unspiderfy = () => {
-        if (this.spider) {
+        const mapgl = this.getMapGL()
+
+        if (this.spider && mapgl) {
             this.spider.unspiderfy()
-            this.getMapGL().off('zoom', this.unspiderfy)
+            mapgl.off('zoom', this.unspiderfy)
         }
     }
 

--- a/src/layers/Cluster.js
+++ b/src/layers/Cluster.js
@@ -131,11 +131,12 @@ class Cluster extends Layer {
     }
 
     unspiderfy = () => {
-        const mapgl = this.getMapGL()
-
-        if (this.spider && mapgl) {
+        if (this.spider) {
             this.spider.unspiderfy()
-            mapgl.off('zoom', this.unspiderfy)
+            const mapgl = this.getMapGL()
+            if (mapgl) {
+                mapgl.off('zoom', this.unspiderfy)
+            }
         }
     }
 


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-12583

This PR adds an extra check if the map still exists before removing an event handler to "unspiderify" an event cluster.