### PR TITLE
feat: earth engine aggregations for catchment areas (DHIS2-11969)

### DIFF
--- a/src/utils/earthengine.js
+++ b/src/utils/earthengine.js
@@ -21,10 +21,18 @@ const workerOptions = [
 ]
 
 // Returns the layer options that should be passed to the EE worker
-export const getWorkerOptions = options =>
-    Object.keys(options)
+export const getWorkerOptions = opts => {
+    const options = Object.keys(opts)
         .filter(option => workerOptions.includes(option))
         .reduce((obj, key) => {
-            obj[key] = options[key]
+            obj[key] = opts[key]
             return obj
         }, {})
+
+    // Exclude point features if no buffer
+    if (options.data && !options.buffer) {
+        options.data = options.data.filter(d => d.geometry.type !== 'Point')
+    }
+
+    return options
+}


### PR DESCRIPTION
This PR will perform Earth Engine aggregations for catchment areas. 

Partly fixes: https://jira.dhis2.org/browse/DHIS2-11969

Catchment areas can not be combined with point facility buffers, so this issue was solved by excluding points when no buffer is assigned. When facility points are removed, aggregations will be computed for the remaining polygon features. The facility points are still shown as black dots on the map. 

After this PR: 
![Screenshot 2022-02-23 at 11 43 48](https://user-images.githubusercontent.com/548708/155304599-d6a85782-e28b-44ff-a86b-9f0b3255583b.png)
