### PR TITLE
fix: use tileScale to avoid ee timeout

### DIFF
--- a/src/earthengine/ee_worker.js
+++ b/src/earthengine/ee_worker.js
@@ -16,6 +16,7 @@ import { getBufferGeometry } from '../utils/buffers'
 // https://groups.google.com/g/google-earth-engine-developers/c/nvlbqxrnzDk/m/QuyWxGt9AQAJ
 
 const FEATURE_STYLE = { color: 'FFA500', strokeWidth: 2 }
+const DEFAULT_TILE_SCALE = 1
 
 class EarthEngineWorker {
     constructor(options = {}) {
@@ -233,7 +234,7 @@ class EarthEngineWorker {
             aggregationType,
             band,
             legend,
-            tileScale = 1,
+            tileScale = DEFAULT_TILE_SCALE,
         } = this.options
         const singleAggregation = !Array.isArray(aggregationType)
         const useHistogram =

--- a/src/earthengine/ee_worker.js
+++ b/src/earthengine/ee_worker.js
@@ -101,15 +101,8 @@ class EarthEngineWorker {
             return this.eeImage
         }
 
-        const {
-            datasetId,
-            filter,
-            mosaic,
-            band,
-            bandReducer,
-            mask,
-            methods,
-        } = this.options
+        const { datasetId, filter, mosaic, band, bandReducer, mask, methods } =
+            this.options
 
         let eeImage
 
@@ -235,13 +228,21 @@ class EarthEngineWorker {
         if (config) {
             this.setOptions(config)
         }
-        const { format, aggregationType, band, legend } = this.options
+        const {
+            format,
+            aggregationType,
+            band,
+            legend,
+            tileScale = 1,
+        } = this.options
         const singleAggregation = !Array.isArray(aggregationType)
         const useHistogram =
             singleAggregation && hasClasses(aggregationType) && legend
         const image = await this.getImage()
         const scale = this.eeScale
         const collection = this.getFeatureCollection() // TODO: Throw error if no feature collection
+
+        console.log('tileScale', tileScale)
 
         if (collection) {
             if (format === 'FeatureCollection') {
@@ -267,7 +268,12 @@ class EarthEngineWorker {
 
                 return getInfo(
                     image
-                        .reduceRegions(collection, reducer, scale)
+                        .reduceRegions({
+                            collection,
+                            reducer,
+                            scale,
+                            tileScale,
+                        })
                         .select(['histogram'], null, false)
                 ).then(data =>
                     getHistogramStatistics({
@@ -285,6 +291,7 @@ class EarthEngineWorker {
                     collection,
                     reducer,
                     scale,
+                    tileScale,
                 })
 
                 if (this.eeImageBands) {
@@ -292,6 +299,7 @@ class EarthEngineWorker {
                         collection: aggFeatures,
                         reducer,
                         scale,
+                        tileScale,
                     })
 
                     band.forEach(band =>

--- a/src/earthengine/ee_worker.js
+++ b/src/earthengine/ee_worker.js
@@ -242,8 +242,6 @@ class EarthEngineWorker {
         const scale = this.eeScale
         const collection = this.getFeatureCollection() // TODO: Throw error if no feature collection
 
-        console.log('tileScale', tileScale)
-
         if (collection) {
             if (format === 'FeatureCollection') {
                 const { datasetId } = this.options

--- a/src/utils/earthengine.js
+++ b/src/utils/earthengine.js
@@ -19,6 +19,7 @@ const workerOptions = [
     'methods',
     'mosaic',
     'params',
+    'tileScale',
 ]
 
 // Returns the layer options that should be passed to the EE worker


### PR DESCRIPTION
This PR will fix a timeout issue with EE aggregations when multiple bands (e.g. age groups) are selected. The fix is to use include a "tileScale" option for ee.Image.reduceRegion: 
 https://developers.google.com/earth-engine/apidocs/ee-image-reduceregion
https://gis.stackexchange.com/questions/373250/understanding-tilescale-in-earth-engine

If the "tileScale" is not passed to the EE layer it will be set to default 1. 

After this fix we are able to aggregate population data for all age groups within all districts and chiefdoms in Sierra Leone. 
