### PR TITLE
fix: vector style visibility

### DIFF
--- a/src/layers/VectorStyle.js
+++ b/src/layers/VectorStyle.js
@@ -15,8 +15,6 @@ class VectorStyle extends Evented {
     // Before we change the style we remove all overlays for a proper cleanup
     // After the style is changed and ready, we add the overlays back again
     async toggleVectorStyle(isOnMap, style, beforeId) {
-        this._visibleLayers = []
-
         await this.removeOtherLayers()
         this._map.setBeforeLayerId(beforeId)
 
@@ -26,6 +24,7 @@ class VectorStyle extends Evented {
             await this.setStyle(style)
             this._map._styleIsLoading = false
 
+            // Store id of all style layers that are visible
             this._visibleLayers = this._map
                 .getMapGL()
                 .getStyle()
@@ -40,8 +39,16 @@ class VectorStyle extends Evented {
     // Add vector style to map
     async addTo(map) {
         this._map = map
-        const { url, beforeId } = this.options
+        const { url, beforeId, isVisible } = this.options
         await this.toggleVectorStyle(true, url, beforeId)
+
+        // Set vector style visibility after added to the map
+        if (
+            this.isVisible() === false ||
+            (this.isVisible() !== true && isVisible === false)
+        ) {
+            setVisibility(false)
+        }
     }
 
     // Remove vector style from map, reset to default map style

--- a/src/layers/VectorStyle.js
+++ b/src/layers/VectorStyle.js
@@ -8,7 +8,6 @@ class VectorStyle extends Evented {
         this.options = options
         this._visibleLayers = []
         this._isOnMap = false
-        this._isVisible = true
     }
 
     // Changing vector style will also delete all overlays on the map
@@ -45,7 +44,7 @@ class VectorStyle extends Evented {
         // Set vector style visibility after added to the map
         if (
             this.isVisible() === false ||
-            (this.isVisible() !== true && isVisible === false)
+            (this.isVisible() === undefined && isVisible === false)
         ) {
             this.setVisibility(false)
         }

--- a/src/layers/VectorStyle.js
+++ b/src/layers/VectorStyle.js
@@ -47,7 +47,7 @@ class VectorStyle extends Evented {
             this.isVisible() === false ||
             (this.isVisible() !== true && isVisible === false)
         ) {
-            setVisibility(false)
+            this.setVisibility(false)
         }
     }
 


### PR DESCRIPTION
This PR will add to methods that were missing for vector style: 

1. `setVisibility(isVisible)` - changes the visibility for all layers in the vector style
2. `isVisible()` - returns the if the layer is visible (true) or not (false) or not defined (undefined)

The id for all layers that can have the visibility changed are kept in `this._visibleLayers`. 