### PR TITLE
chore: revert label changes not needed

### DIFF
--- a/src/utils/labels.js
+++ b/src/utils/labels.js
@@ -37,19 +37,6 @@ export const labelSource = (features, { fontSize }, isBoundary) => ({
     ),
 })
 
-// const LABEL_DISPLAY_OPTION_NAME_ONLY = 'NAME'
-const LABEL_DISPLAY_OPTION_NAME_AND_VALUE = 'NAME_AND_VALUE'
-const LABEL_DISPLAY_OPTION_VALUE_ONLY = 'VALUE'
-
-export const getLabelDisplayOptionFormat = labelDisplayOption => {
-    if (labelDisplayOption === LABEL_DISPLAY_OPTION_NAME_AND_VALUE) {
-        return ['format', ['get', 'name'], '\n', ['get', 'value']]
-    } else if (labelDisplayOption === LABEL_DISPLAY_OPTION_VALUE_ONLY) {
-        return '{value}'
-    }
-    return '{name}'
-}
-
 export const labelLayer = ({
     id,
     label,
@@ -66,7 +53,7 @@ export const labelLayer = ({
         id: `${id}-label`,
         source: `${id}-label`,
         layout: {
-            'text-field': getLabelDisplayOptionFormat(label),
+            'text-field': label || '{name}',
             'text-font': [fonts[font]],
             'text-size': size,
             'text-anchor': ['get', 'anchor'],


### PR DESCRIPTION
This PR will revert changes to utils/labels.js except adding value to the feature properties. 

Maplibre GL JS support template strings out-of-the-box like:
-  '{name}'
- '{name}\n{value}'

This could be passed in as the "label" option. 
