### PR TITLE
feat: support SVG symbols (DHIS2-14440)

### DIFF
--- a/src/layers/Layer.js
+++ b/src/layers/Layer.js
@@ -37,7 +37,11 @@ class Layer extends Evented {
         const beforeId = map.getBeforeLayerId()
 
         if (images) {
-            await addImages(mapgl, images)
+            try {
+                await addImages(mapgl, images)
+            } catch (error) {
+                this.onError(error)
+            }
         }
 
         Object.keys(source).forEach(id => {
@@ -345,6 +349,16 @@ class Layer extends Evented {
             this._map.showLabel(content, evt.lngLat)
         } else {
             this._map.hideLabel()
+        }
+    }
+
+    onError(error) {
+        const { onError } = this.options
+
+        if (onError) {
+            onError(error)
+        } else {
+            console.error(error)
         }
     }
 }

--- a/src/layers/Layer.js
+++ b/src/layers/Layer.js
@@ -352,6 +352,7 @@ class Layer extends Evented {
         }
     }
 
+    // Pass layer error to calling app if handler exists
     onError(error) {
         const { onError } = this.options
 

--- a/src/utils/images.js
+++ b/src/utils/images.js
@@ -1,23 +1,71 @@
+const imageWidth = 16
+const imageHeight = 16
+
+const addImage = (map, name, img) => {
+    if (!map.hasImage(name)) {
+        map.addImage(name, img)
+    }
+}
+
+// https://stackoverflow.com/questions/69314193/cannot-create-bitmap-from-svg
+const dataUri2image = dataUri =>
+    new Promise(resolve => {
+        const img = new Image(imageWidth, imageHeight)
+        img.onload = () => resolve(img)
+        img.onerror = resolve
+        img.src = dataUri
+    })
+// https://github.com/mapbox/mapbox-gl-js/issues/5529
+const fetchSvg = url =>
+    fetch(url, { credentials: 'include' })
+        .then(response => response.text())
+        .then(svg => `data:image/svg+xml;charset=utf-8;base64,${btoa(svg)}`)
+        .then(dataUri2image)
+
+/*        
+const transparentPngUrl =
+    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQYV2NgAAIAAAUAAarVyFEAAAAASUVORK5CYII='
+
+const addfallbackImage = (map, url) =>
+    new Promise((resolve, reject) =>
+        map.loadImage(transparentPngUrl, (error, img) => {
+            if (error) {
+                reject(error)
+            }
+            addImage(map, url, img)
+            resolve(img)
+        })
+    )
+*/
+
+const loadImage = map => url =>
+    new Promise(resolve => {
+        if (url.endsWith('.svg')) {
+            fetchSvg(url)
+                .then(img => {
+                    addImage(map, url, img)
+                    resolve(img)
+                })
+                .catch(error => {
+                    console.log('Something wrong with the SVG', url, error)
+                    resolve()
+                })
+        } else {
+            map.loadImage(url, (error, img) => {
+                if (error) {
+                    console.log('Something wrong with the image', url, error)
+                }
+                if (img) {
+                    addImage(map, url, img)
+                }
+                resolve(img)
+            })
+        }
+    })
+
 // Load and add images to map sprite
 export const addImages = async (map, images) =>
-    Promise.all(
-        images.map(
-            url =>
-                new Promise((resolve, reject) => {
-                    map.loadImage(url, (error, img) => {
-                        if (error) {
-                            reject(error)
-                        }
-
-                        if (!map.hasImage(url)) {
-                            map.addImage(url, img)
-                        }
-
-                        resolve(img)
-                    })
-                })
-        )
-    )
+    Promise.all(images.map(loadImage(map)))
 
 // Include cookies for cross-origin image requests
 export const transformRequest = (url, resourceType) =>

--- a/src/utils/images.js
+++ b/src/utils/images.js
@@ -1,43 +1,35 @@
-const imageWidth = 16
-const imageHeight = 16
+// Only one SVG icon size is currently suppored
+const svgWidth = 16
+const svgHeight = 16
 
+const credentials = 'include'
+
+// Add image to map sprite if not exist
 const addImage = (map, name, img) => {
     if (!map.hasImage(name)) {
         map.addImage(name, img)
     }
 }
 
-// https://stackoverflow.com/questions/69314193/cannot-create-bitmap-from-svg
+// Creates image from SVG data URI
 const dataUri2image = dataUri =>
-    new Promise(resolve => {
-        const img = new Image(imageWidth, imageHeight)
+    new Promise((resolve, reject) => {
+        const img = new Image(svgWidth, svgHeight)
         img.onload = () => resolve(img)
-        img.onerror = resolve
+        img.onerror = reject
         img.src = dataUri
     })
-// https://github.com/mapbox/mapbox-gl-js/issues/5529
+
+// Fetch SVG and convert to Base64 data URI
 const fetchSvg = url =>
-    fetch(url, { credentials: 'include' })
+    fetch(url, { credentials })
         .then(response => response.text())
-        .then(svg => `data:image/svg+xml;charset=utf-8;base64,${btoa(svg)}`)
+        .then(
+            svg => `data:image/svg+xml;charset=utf-8;base64,${window.btoa(svg)}`
+        )
         .then(dataUri2image)
 
-/*        
-const transparentPngUrl =
-    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQYV2NgAAIAAAUAAarVyFEAAAAASUVORK5CYII='
-
-const addfallbackImage = (map, url) =>
-    new Promise((resolve, reject) =>
-        map.loadImage(transparentPngUrl, (error, img) => {
-            if (error) {
-                reject(error)
-            }
-            addImage(map, url, img)
-            resolve(img)
-        })
-    )
-*/
-
+// Load and add image to map
 const loadImage = map => url =>
     new Promise(resolve => {
         if (url.endsWith('.svg')) {
@@ -47,13 +39,13 @@ const loadImage = map => url =>
                     resolve(img)
                 })
                 .catch(error => {
-                    console.log('Something wrong with the SVG', url, error)
+                    console.log('SVG not added', url, error)
                     resolve()
                 })
         } else {
             map.loadImage(url, (error, img) => {
                 if (error) {
-                    console.log('Something wrong with the image', url, error)
+                    console.log('Image not loaded', url, error)
                 }
                 if (img) {
                     addImage(map, url, img)
@@ -69,4 +61,4 @@ export const addImages = async (map, images) =>
 
 // Include cookies for cross-origin image requests
 export const transformRequest = (url, resourceType) =>
-    resourceType === 'Image' ? { url, credentials: 'include' } : null
+    resourceType === 'Image' ? { url, credentials } : null

--- a/src/utils/images.js
+++ b/src/utils/images.js
@@ -38,15 +38,11 @@ const loadImage = map => url =>
                     addImage(map, url, img)
                     resolve(img)
                 })
-                .catch(error => {
-                    console.log('SVG not added', url, error)
+                .catch(() => {
                     resolve()
                 })
         } else {
             map.loadImage(url, (error, img) => {
-                if (error) {
-                    console.log('Image not loaded', url, error)
-                }
                 if (img) {
                     addImage(map, url, img)
                 }
@@ -56,8 +52,15 @@ const loadImage = map => url =>
     })
 
 // Load and add images to map sprite
-export const addImages = async (map, images) =>
-    Promise.all(images.map(loadImage(map)))
+export const addImages = async (map, images) => {
+    const result = await Promise.all(images.map(loadImage(map)))
+    const errorIndex = result.indexOf(undefined)
+
+    // Throws error for the first image not found
+    if (errorIndex !== -1) {
+        throw `Symbol not found: ${images[errorIndex]}`
+    }
+}
 
 // Include cookies for cross-origin image requests
 export const transformRequest = (url, resourceType) =>


### PR DESCRIPTION
This PR adds support for SVG images as map symbols. 

Fixes: 
https://dhis2.atlassian.net/browse/DHIS2-14440

Partly fixes: 
https://dhis2.atlassian.net/browse/DHIS2-14438

MapLibre GL JS don't support SVG images: https://github.com/mapbox/mapbox-gl-js/issues/5529
We translate the SVG image to a HTML Image element before it's added to the map. 

We need to know the size when the SVG is translated. Currently we only support the size used for symbols in DHIS2 (16x16). This could be expanded later (by passing in with and height together with the SVG URL). 

The PR also includes a fix so the addImages Promise.all will resolve if one image could not be loaded. If there is an issue with one image, we will write it to the console, but still show the others. 

After this PR (the triangle symbol is originally SVG): 
![Screenshot 2023-01-06 at 10 04 40](https://user-images.githubusercontent.com/548708/210977033-647e4b42-0561-48e6-9439-a362faae4f66.png)


