### PR TITLE
feat: fit bounds options support

### DIFF
--- a/src/Map.js
+++ b/src/Map.js
@@ -70,12 +70,15 @@ export class MapGL extends Evented {
         }
     }
 
-    fitBounds(bounds) {
+    fitBounds(bounds, fitBoundsOptions) {
         if (bounds) {
-            this._mapgl.fitBounds(bounds, {
-                padding: 10,
-                duration: 0,
-            })
+            this._mapgl.fitBounds(
+                bounds,
+                fitBoundsOptions || {
+                    padding: 10,
+                    duration: 0,
+                }
+            )
         }
     }
 


### PR DESCRIPTION
This PR will allow fitBoundsOptions to be passed in with the map.fitBounds method. This might include map content padding which is useful to control for printed maps. 

The options are documented here: https://maplibre.org/maplibre-gl-js-docs/api/map/#map#fitbounds