### PR TITLE
fix: use cell centroids in calculations (DHIS2-14261)

### DIFF
--- a/src/earthengine/ee_worker.js
+++ b/src/earthengine/ee_worker.js
@@ -283,7 +283,6 @@ class EarthEngineWorker {
                     })
                 )
             } else if (!singleAggregation && aggregationType.length) {
-                console.log('aggregate')
                 const reducer = combineReducers(ee)(aggregationType)
                 const props = [...aggregationType]
 

--- a/src/earthengine/ee_worker.js
+++ b/src/earthengine/ee_worker.js
@@ -283,6 +283,7 @@ class EarthEngineWorker {
                     })
                 )
             } else if (!singleAggregation && aggregationType.length) {
+                console.log('aggregate')
                 const reducer = combineReducers(ee)(aggregationType)
                 const props = [...aggregationType]
 

--- a/src/earthengine/ee_worker_utils.js
+++ b/src/earthengine/ee_worker_utils.js
@@ -21,6 +21,7 @@ export const getInfo = instance =>
 // Combine multiple aggregation types/reducers
 // unweighted means that centroids are used for each grid cell
 // https://developers.google.com/earth-engine/guides/reducers_intro
+// https://developers.google.com/earth-engine/guides/reducers_reduce_region#pixels-in-the-region
 export const combineReducers = ee => types =>
     types.reduce(
         (r, t, i) =>

--- a/src/earthengine/ee_worker_utils.js
+++ b/src/earthengine/ee_worker_utils.js
@@ -19,14 +19,15 @@ export const getInfo = instance =>
     )
 
 // Combine multiple aggregation types/reducers
+// unweighted means that centroids are used for each grid cell
 // https://developers.google.com/earth-engine/guides/reducers_intro
 export const combineReducers = ee => types =>
     types.reduce(
         (r, t, i) =>
             i === 0
-                ? r[t]()
+                ? r[t]().unweighted()
                 : r.combine({
-                      reducer2: ee.Reducer[t](),
+                      reducer2: ee.Reducer[t]().unweighted(),
                       sharedInputs: true,
                   }),
         ee.Reducer


### PR DESCRIPTION
Fixes: https://dhis2.atlassian.net/browse/DHIS2-14261

When we aggregate population data to org units on Google Earth Engine, we currently count a pixel (100x100m) if "at least 0.5% of the pixel is in the region". WorldPop recommends us to use the pixel centroid instead, meaning that the pixel will be counted if the centroid is within the region. 

The different methods gives a small difference. For the Badjia chiefdom in Sierra Leone the population is:
- 12091 when at least 0.5% in region is used
- 12086 when centroid in region is used (5 less)

To use centroid we need to call unweighted() on the reducers: 
https://developers.google.com/earth-engine/guides/reducers_reduce_region#pixels-in-the-region