### PR TITLE
fix: toggle visibility for donut cluster (DHIS2-14928)

### DIFF
--- a/src/layers/DonutCluster.js
+++ b/src/layers/DonutCluster.js
@@ -113,8 +113,6 @@ class DonutCluster extends Cluster {
                 this.clusters[id].setVisibility(isVisible)
             }
         }
-
-        this._isVisible = isVisible
     }
 
     // Sort cluster features after legend colors before spiderfy

--- a/src/layers/DonutCluster.js
+++ b/src/layers/DonutCluster.js
@@ -105,6 +105,18 @@ class DonutCluster extends Cluster {
         }
     }
 
+    setVisibility(isVisible) {
+        super.setVisibility(isVisible)
+
+        if (this.isOnMap()) {
+            for (const id in this.clusters) {
+                this.clusters[id].setVisibility(isVisible)
+            }
+        }
+
+        this._isVisible = isVisible
+    }
+
     // Sort cluster features after legend colors before spiderfy
     sortClusterFeatures = features => {
         const colors = this.options.groups.map(g => g.color)

--- a/src/layers/DonutMarker.js
+++ b/src/layers/DonutMarker.js
@@ -17,6 +17,10 @@ class DonutMarker extends Marker {
         }
     }
 
+    setVisibility(isVisible) {
+        this.getElement().style.display = isVisible ? 'block' : 'none'
+    }
+
     onClick = evt => {
         evt.stopPropagation()
         this.fire('click')

--- a/src/utils/layers.js
+++ b/src/utils/layers.js
@@ -110,6 +110,7 @@ export const clusterCountLayer = ({ id, color }) => ({
         'text-field': '{point_count_abbreviated}',
         'text-font': defaults.textFont,
         'text-size': defaults.textSize,
+        'text-allow-overlap': true,
     },
     paint: {
         'text-color': color || defaults.textColor,


### PR DESCRIPTION
Fixes: https://dhis2.atlassian.net/browse/DHIS2-14928

This PR makes it possible to toggle visibility for donut clusters:

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/548708/225142310-b430b0f1-9dda-4f1b-9ecc-38f1a9c6dd52.gif)

The PR also contains a change to allow cluster counts to overlap (to make sure all clusters have a number):
<img width="298" alt="Screenshot 2023-03-14 at 22 22 12" src="https://user-images.githubusercontent.com/548708/225142771-799aa73c-8ffd-4cc4-b62b-71e3269ebecc.png">

Before: 
<img width="470" alt="Screenshot 2023-03-13 at 10 23 51" src="https://user-images.githubusercontent.com/548708/225143014-4d9e44c8-c069-42d6-92a1-e0fcb4c80324.png">
