### PR TITLE
fix: draw layers with opacity (DHIS2-15793)

### DIFF
--- a/src/layers/Choropleth.js
+++ b/src/layers/Choropleth.js
@@ -12,15 +12,15 @@ class Choropleth extends Layer {
 
     createLayers() {
         const id = this.getId()
-        const { color, label, labelStyle } = this.options
+        const { color, opacity, label, labelStyle } = this.options
         const isInteractive = true
 
-        this.addLayer(polygonLayer({ id, color }), { isInteractive })
-        this.addLayer(outlineLayer({ id }))
-        this.addLayer(pointLayer({ id, color }), { isInteractive })
+        this.addLayer(polygonLayer({ id, color, opacity }), { isInteractive })
+        this.addLayer(outlineLayer({ id, opacity }))
+        this.addLayer(pointLayer({ id, color, opacity }), { isInteractive })
 
         if (label) {
-            this.addLayer(labelLayer({ id, label, ...labelStyle }))
+            this.addLayer(labelLayer({ id, label, ...labelStyle, opacity }))
         }
     }
 }

--- a/src/layers/Layer.js
+++ b/src/layers/Layer.js
@@ -60,7 +60,7 @@ class Layer extends Evented {
             this.setVisibility(false)
         }
 
-        if (opacity) {
+        if (opacity !== undefined) {
             this.setOpacity(opacity)
         }
 

--- a/src/utils/__tests__/labels.spec.js
+++ b/src/utils/__tests__/labels.spec.js
@@ -1,5 +1,5 @@
 import { labelLayer } from '../labels'
-import { opacity as defaultOpacity } from '../style'
+import defaults from '../style'
 
 const id = 'abc'
 const opacity = 0.5
@@ -10,6 +10,6 @@ describe('labels', () => {
     })
 
     it('Should set default opacity for label layer', () => {
-        expect(labelLayer({ id }).paint['text-opacity']).toBe(defaultOpacity)
+        expect(labelLayer({ id }).paint['text-opacity']).toBe(defaults.opacity)
     })
 })

--- a/src/utils/__tests__/labels.spec.js
+++ b/src/utils/__tests__/labels.spec.js
@@ -1,0 +1,15 @@
+import { labelLayer } from '../labels'
+import { opacity as defaultOpacity } from '../style'
+
+const id = 'abc'
+const opacity = 0.5
+
+describe('labels', () => {
+    it('Should set opacity for for label layer', () => {
+        expect(labelLayer({ id, opacity }).paint['text-opacity']).toBe(opacity)
+    })
+
+    it('Should set default opacity for label layer', () => {
+        expect(labelLayer({ id }).paint['text-opacity']).toBe(defaultOpacity)
+    })
+})

--- a/src/utils/__tests__/layers.spec.js
+++ b/src/utils/__tests__/layers.spec.js
@@ -1,0 +1,54 @@
+import {
+    pointLayer,
+    lineLayer,
+    polygonLayer,
+    outlineLayer,
+    symbolLayer,
+    clusterLayer,
+    clusterCountLayer,
+} from '../layers'
+import { opacity as defaultOpacity } from '../style'
+
+const id = 'abc'
+const color = '#000000'
+const opacity = 0.5
+
+describe('layers', () => {
+    it('Should set opacity for different layer types', () => {
+        expect(pointLayer({ id, color, opacity }).paint['circle-opacity']).toBe(
+            opacity
+        )
+        expect(lineLayer({ id, opacity }).paint['line-opacity']).toBe(opacity)
+        expect(polygonLayer({ id, color, opacity }).paint['fill-opacity']).toBe(
+            opacity
+        )
+        expect(outlineLayer({ id, opacity }).paint['line-opacity']).toBe(
+            opacity
+        )
+        expect(symbolLayer({ id, opacity }).paint['icon-opacity']).toBe(opacity)
+        expect(clusterLayer({ id, opacity }).paint['circle-opacity']).toBe(
+            opacity
+        )
+        expect(clusterCountLayer({ id, opacity }).paint['text-opacity']).toBe(
+            opacity
+        )
+    })
+
+    it('Should set default opacity for different layer types', () => {
+        expect(pointLayer({ id, color }).paint['circle-opacity']).toBe(
+            defaultOpacity
+        )
+        expect(lineLayer({ id }).paint['line-opacity']).toBe(defaultOpacity)
+        expect(polygonLayer({ id, color }).paint['fill-opacity']).toBe(
+            defaultOpacity
+        )
+        expect(outlineLayer({ id }).paint['line-opacity']).toBe(defaultOpacity)
+        expect(symbolLayer({ id }).paint['icon-opacity']).toBe(defaultOpacity)
+        expect(clusterLayer({ id }).paint['circle-opacity']).toBe(
+            defaultOpacity
+        )
+        expect(clusterCountLayer({ id }).paint['text-opacity']).toBe(
+            defaultOpacity
+        )
+    })
+})

--- a/src/utils/__tests__/layers.spec.js
+++ b/src/utils/__tests__/layers.spec.js
@@ -7,7 +7,7 @@ import {
     clusterLayer,
     clusterCountLayer,
 } from '../layers'
-import { opacity as defaultOpacity } from '../style'
+import defaults from '../style'
 
 const id = 'abc'
 const color = '#000000'
@@ -36,19 +36,21 @@ describe('layers', () => {
 
     it('Should set default opacity for different layer types', () => {
         expect(pointLayer({ id, color }).paint['circle-opacity']).toBe(
-            defaultOpacity
+            defaults.opacity
         )
-        expect(lineLayer({ id }).paint['line-opacity']).toBe(defaultOpacity)
+        expect(lineLayer({ id }).paint['line-opacity']).toBe(defaults.opacity)
         expect(polygonLayer({ id, color }).paint['fill-opacity']).toBe(
-            defaultOpacity
+            defaults.opacity
         )
-        expect(outlineLayer({ id }).paint['line-opacity']).toBe(defaultOpacity)
-        expect(symbolLayer({ id }).paint['icon-opacity']).toBe(defaultOpacity)
+        expect(outlineLayer({ id }).paint['line-opacity']).toBe(
+            defaults.opacity
+        )
+        expect(symbolLayer({ id }).paint['icon-opacity']).toBe(defaults.opacity)
         expect(clusterLayer({ id }).paint['circle-opacity']).toBe(
-            defaultOpacity
+            defaults.opacity
         )
         expect(clusterCountLayer({ id }).paint['text-opacity']).toBe(
-            defaultOpacity
+            defaults.opacity
         )
     })
 })

--- a/src/utils/labels.js
+++ b/src/utils/labels.js
@@ -1,6 +1,7 @@
 import area from '@turf/area'
 import polylabel from 'polylabel'
 import { featureCollection } from './geometry'
+import defaults from './style'
 
 // Default fonts
 const fonts = {
@@ -44,6 +45,7 @@ export const labelLayer = ({
     fontStyle,
     fontWeight,
     color,
+    opacity,
 }) => {
     const font = `${fontStyle || 'normal'}-${fontWeight || 'normal'}`
     const size = fontSize ? parseInt(fontSize, 10) : 12
@@ -61,6 +63,7 @@ export const labelLayer = ({
         },
         paint: {
             'text-color': color ? color : ['get', 'color'],
+            'text-opacity': opacity || defaults.opacity,
         },
     }
 }

--- a/src/utils/labels.js
+++ b/src/utils/labels.js
@@ -63,7 +63,7 @@ export const labelLayer = ({
         },
         paint: {
             'text-color': color ? color : ['get', 'color'],
-            'text-opacity': opacity || defaults.opacity,
+            'text-opacity': opacity ?? defaults.opacity,
         },
     }
 }

--- a/src/utils/layers.js
+++ b/src/utils/layers.js
@@ -23,6 +23,7 @@ export const pointLayer = ({
     strokeColor,
     width,
     radius,
+    opacity,
     source,
     filter,
 }) => ({
@@ -32,49 +33,61 @@ export const pointLayer = ({
     paint: {
         'circle-color': colorExpr(color || defaults.noDataColor),
         'circle-radius': radiusExpr(radius || defaults.radius),
+        'circle-opacity': opacity || defaults.opacity,
         'circle-stroke-width': widthExpr(width),
         'circle-stroke-color': strokeColor || defaults.strokeColor,
+        'circle-stroke-opacity': opacity || defaults.opacity,
     },
     filter: filter || isPointNoSymbol,
 })
 
 // Layer with line features
-export const lineLayer = ({ id, color, width, source, filter }) => ({
+export const lineLayer = ({ id, color, width, opacity, source, filter }) => ({
     id: `${id}-line`,
     type: 'line',
     source: source || id,
     paint: {
         'line-color': color,
         'line-width': widthExpr(width),
+        'line-opacity': opacity || defaults.opacity,
     },
     filter: filter || isLine,
 })
 
 // Layer with polygon features
-export const polygonLayer = ({ id, color, source, filter }) => ({
+export const polygonLayer = ({ id, color, opacity, source, filter }) => ({
     id: `${id}-polygon`,
     type: 'fill',
     source: source || id,
     paint: {
         'fill-color': colorExpr(color || defaults.noDataColor),
+        'fill-opacity': opacity || defaults.opacity,
     },
     filter: filter || isPolygon,
 })
 
 // Polygon outline and hover state
 // https://github.com/mapbox/mapbox-gl-js/issues/3018
-export const outlineLayer = ({ id, color, width, source, filter }) => ({
+export const outlineLayer = ({
+    id,
+    color,
+    width,
+    opacity,
+    source,
+    filter,
+}) => ({
     id: `${id}-outline`,
     type: 'line',
     source: source || id,
     paint: {
         'line-color': color || defaults.strokeColor,
         'line-width': widthExpr(width),
+        'line-opacity': opacity || defaults.opacity,
     },
     filter: filter || isPolygon,
 })
 
-export const symbolLayer = ({ id, source, filter }) => ({
+export const symbolLayer = ({ id, opacity, source, filter }) => ({
     id: `${id}-symbol`,
     type: 'symbol',
     source: source || id,
@@ -83,11 +96,14 @@ export const symbolLayer = ({ id, source, filter }) => ({
         'icon-size': 1,
         'icon-allow-overlap': true,
     },
+    paint: {
+        'icon-opacity': opacity || defaults.opacity,
+    },
     filter: filter || isSymbol,
 })
 
 // Layer with cluster (circles)
-export const clusterLayer = ({ id, color, strokeColor }) => ({
+export const clusterLayer = ({ id, color, strokeColor, opacity }) => ({
     id: `${id}-cluster`,
     type: 'circle',
     source: id,
@@ -95,13 +111,15 @@ export const clusterLayer = ({ id, color, strokeColor }) => ({
     paint: {
         'circle-color': color,
         'circle-radius': clusterRadiusExpr,
+        'circle-opacity': opacity || defaults.opacity,
         'circle-stroke-color': strokeColor,
         'circle-stroke-width': defaults.strokeWidth,
+        'circle-stroke-opacity': opacity || defaults.opacity,
     },
 })
 
 //  Layer with cluster counts (text)
-export const clusterCountLayer = ({ id, color }) => ({
+export const clusterCountLayer = ({ id, color, opacity }) => ({
     id: `${id}-count`,
     type: 'symbol',
     source: id,
@@ -114,5 +132,6 @@ export const clusterCountLayer = ({ id, color }) => ({
     },
     paint: {
         'text-color': color || defaults.textColor,
+        'text-opacity': opacity || defaults.opacity,
     },
 })

--- a/src/utils/layers.js
+++ b/src/utils/layers.js
@@ -33,10 +33,10 @@ export const pointLayer = ({
     paint: {
         'circle-color': colorExpr(color || defaults.noDataColor),
         'circle-radius': radiusExpr(radius || defaults.radius),
-        'circle-opacity': opacity || defaults.opacity,
+        'circle-opacity': opacity ?? defaults.opacity,
         'circle-stroke-width': widthExpr(width),
         'circle-stroke-color': strokeColor || defaults.strokeColor,
-        'circle-stroke-opacity': opacity || defaults.opacity,
+        'circle-stroke-opacity': opacity ?? defaults.opacity,
     },
     filter: filter || isPointNoSymbol,
 })
@@ -49,7 +49,7 @@ export const lineLayer = ({ id, color, width, opacity, source, filter }) => ({
     paint: {
         'line-color': color,
         'line-width': widthExpr(width),
-        'line-opacity': opacity || defaults.opacity,
+        'line-opacity': opacity ?? defaults.opacity,
     },
     filter: filter || isLine,
 })
@@ -61,7 +61,7 @@ export const polygonLayer = ({ id, color, opacity, source, filter }) => ({
     source: source || id,
     paint: {
         'fill-color': colorExpr(color || defaults.noDataColor),
-        'fill-opacity': opacity || defaults.opacity,
+        'fill-opacity': opacity ?? defaults.opacity,
     },
     filter: filter || isPolygon,
 })
@@ -82,7 +82,7 @@ export const outlineLayer = ({
     paint: {
         'line-color': color || defaults.strokeColor,
         'line-width': widthExpr(width),
-        'line-opacity': opacity || defaults.opacity,
+        'line-opacity': opacity ?? defaults.opacity,
     },
     filter: filter || isPolygon,
 })
@@ -97,7 +97,7 @@ export const symbolLayer = ({ id, opacity, source, filter }) => ({
         'icon-allow-overlap': true,
     },
     paint: {
-        'icon-opacity': opacity || defaults.opacity,
+        'icon-opacity': opacity ?? defaults.opacity,
     },
     filter: filter || isSymbol,
 })
@@ -111,10 +111,10 @@ export const clusterLayer = ({ id, color, strokeColor, opacity }) => ({
     paint: {
         'circle-color': color,
         'circle-radius': clusterRadiusExpr,
-        'circle-opacity': opacity || defaults.opacity,
+        'circle-opacity': opacity ?? defaults.opacity,
         'circle-stroke-color': strokeColor,
         'circle-stroke-width': defaults.strokeWidth,
-        'circle-stroke-opacity': opacity || defaults.opacity,
+        'circle-stroke-opacity': opacity ?? defaults.opacity,
     },
 })
 
@@ -132,6 +132,6 @@ export const clusterCountLayer = ({ id, color, opacity }) => ({
     },
     paint: {
         'text-color': color || defaults.textColor,
-        'text-opacity': opacity || defaults.opacity,
+        'text-opacity': opacity ?? defaults.opacity,
     },
 })

--- a/src/utils/style.js
+++ b/src/utils/style.js
@@ -13,6 +13,8 @@ export const hoverStrokeMultiplier = 3
 export const eventStrokeColor = '#333333'
 export const clusterCountColor = '#000000'
 
+export const opacity = 1
+
 export const defaultGlyphs =
     'https://fonts.openmaptiles.org/{fontstack}/{range}.pbf'
 
@@ -27,6 +29,7 @@ export default {
     textFont,
     textSize,
     textColor,
+    opacity,
     radius,
     noDataColor,
     strokeColor,


### PR DESCRIPTION
Fixes: https://dhis2.atlassian.net/browse/DHIS2-15793

Our previous behaviour was to first draw the map layer then set the layer opacity. This worked in most cases, but resulted in a small flash for timeline maps as described in [DHIS2-15793](https://dhis2.atlassian.net/browse/DHIS2-15793). 

This PR allows us to pass in opacity for the various MapLibre layer types so it is set before the first map render.

[DHIS2-15793]: https://dhis2.atlassian.net/browse/DHIS2-15793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

If the opacity is not passed in, the fallback opacity of 1 is used, which is the same as MapLibre uses. 

After this PR there the no opacity flashing is no longer present:

![ezgif com-video-to-gif](https://github.com/dhis2/maps-gl/assets/548708/de52a9c6-62fb-4c7b-90bf-6bc77cea1a5a)
