### PR TITLE
feat: generate time series from Earth Engine datasets (DHIS2-16048)

### DIFF
--- a/src/earthengine/__tests__/ee_worker_utils.spec.js
+++ b/src/earthengine/__tests__/ee_worker_utils.spec.js
@@ -1,6 +1,7 @@
 import {
     hasClasses,
     getHistogramStatistics,
+    getFeatureCollectionProperties,
     getFeatureCollectionPropertiesArray,
 } from '../ee_worker_utils'
 
@@ -150,6 +151,15 @@ describe('earthengine', () => {
         expect(itemA['13']).toBe(toAcres(7))
         expect(itemB['9']).toBe(toAcres(5))
         expect(itemB['13']).toBe(toAcres(8))
+    })
+
+    it('Should reduce a feature collection an object of properties', () => {
+        const result = getFeatureCollectionProperties(collection)
+
+        expect(result).toEqual({
+            '2023-10-24': { value: 123 },
+            '2023-10-25': { value: 234 },
+        })
     })
 
     it('Should reduce a feature collection to array of objects with id and properties', () => {

--- a/src/earthengine/__tests__/ee_worker_utils.spec.js
+++ b/src/earthengine/__tests__/ee_worker_utils.spec.js
@@ -1,4 +1,8 @@
-import { hasClasses, getHistogramStatistics } from '../ee_worker_utils'
+import {
+    hasClasses,
+    getHistogramStatistics,
+    getFeatureCollectionPropertiesArray,
+} from '../ee_worker_utils'
 
 const scale = 1000
 
@@ -50,6 +54,26 @@ const data = {
                     13: 8,
                     14: 9,
                 },
+            },
+        },
+    ],
+}
+
+const collection = {
+    type: 'FeatureCollection',
+    features: [
+        {
+            type: 'Feature',
+            id: '2023-10-24',
+            properties: {
+                value: 123,
+            },
+        },
+        {
+            type: 'Feature',
+            id: '2023-10-25',
+            properties: {
+                value: 234,
             },
         },
     ],
@@ -126,5 +150,14 @@ describe('earthengine', () => {
         expect(itemA['13']).toBe(toAcres(7))
         expect(itemB['9']).toBe(toAcres(5))
         expect(itemB['13']).toBe(toAcres(8))
+    })
+
+    it('Should reduce a feature collection to array of objects with id and properties', () => {
+        const result = getFeatureCollectionPropertiesArray(collection)
+
+        expect(result).toEqual([
+            { id: '2023-10-24', value: 123 },
+            { id: '2023-10-25', value: 234 },
+        ])
     })
 })

--- a/src/earthengine/ee_worker.js
+++ b/src/earthengine/ee_worker.js
@@ -340,7 +340,11 @@ class EarthEngineWorker {
 
         const { type, coordinates } = geometry
         const eeGeometry = ee.Geometry[type](coordinates)
-        const eeReducer = ee.Reducer[reducer]()
+
+        // Possible to have one reducer for each band
+        const eeReducer = Array.isArray(reducer)
+            ? reducer.map(r => ee.Reducer[r]())
+            : ee.Reducer[reducer]()
 
         return getInfo(
             ee.FeatureCollection(

--- a/src/earthengine/ee_worker.js
+++ b/src/earthengine/ee_worker.js
@@ -9,7 +9,7 @@ import {
     getClassifiedImage,
     getHistogramStatistics,
     getFeatureCollectionProperties,
-    parseTimeSeries,
+    getFeatureCollectionPropertiesArray,
 } from './ee_worker_utils'
 import { getBufferGeometry } from '../utils/buffers'
 
@@ -351,7 +351,7 @@ class EarthEngineWorker {
                     )
                 )
             )
-        ).then(parseTimeSeries)
+        ).then(getFeatureCollectionPropertiesArray)
     }
 }
 

--- a/src/earthengine/ee_worker.js
+++ b/src/earthengine/ee_worker.js
@@ -352,8 +352,8 @@ class EarthEngineWorker {
 
         if (Array.isArray(reducer)) {
             // Combine multiple reducers
-            // sharedInputs = true means that the reducers are applied to all bands
-            // sharedInouts = false meand that one reducer is applied to each band
+            // sharedInputs = true means that all reducers are applied to all bands
+            // sharedInouts = false means one reducer for each band
             eeReducer = reducer.reduce(
                 (r, t, i) =>
                     i === 0
@@ -372,7 +372,7 @@ class EarthEngineWorker {
             }
         } else {
             // Single reducer
-            reducer = ee.Reducer[reducer]()
+            eeReducer = ee.Reducer[reducer]()
         }
 
         // Retruns a time series array of objects

--- a/src/earthengine/ee_worker_utils.js
+++ b/src/earthengine/ee_worker_utils.js
@@ -138,19 +138,3 @@ export const parseTimeSeries = periodType => collection =>
                 : getDayFromId(f.id),
         ...f.properties,
     }))
-
-const idToDate = id => {
-    const year = id.substring(0, 4)
-    const month = id.substring(4, 6)
-    const day = id.substring(6, 8)
-    const hour = id.substring(9, 11)
-    const forecast = id.slice(-3)
-    const date = new Date(`${year}-${month}-${day}T${hour}:00:00Z`)
-    return date.setHours(date.getHours() + parseInt(forecast))
-}
-
-export const parseAirQuality = collection =>
-    collection.features.map(f => ({
-        id: idToDate(f.id),
-        ...f.properties,
-    }))

--- a/src/earthengine/ee_worker_utils.js
+++ b/src/earthengine/ee_worker_utils.js
@@ -117,24 +117,9 @@ export const getClassifiedImage = (eeImage, { legend = [], params }) => {
     return { eeImage: zones, params: { min, max, palette } }
 }
 
-const getMonthFromId = id => {
-    const year = id.substring(0, 4)
-    const month = id.substring(4, 6)
-    return `${year}-${month}`
-}
-
-const getDayFromId = id => {
-    const year = id.substring(0, 4)
-    const month = id.substring(4, 6)
-    const day = id.substring(6, 8)
-    return `${year}-${month}-${day}`
-}
-
-export const parseTimeSeries = periodType => collection =>
+// Reduce feature collection to array of objects with id and properties
+export const parseTimeSeries = collection =>
     collection.features.map(f => ({
-        id:
-            periodType === 'monthly'
-                ? getMonthFromId(f.id)
-                : getDayFromId(f.id),
+        id: f.id,
         ...f.properties,
     }))

--- a/src/earthengine/ee_worker_utils.js
+++ b/src/earthengine/ee_worker_utils.js
@@ -117,17 +117,25 @@ export const getClassifiedImage = (eeImage, { legend = [], params }) => {
     return { eeImage: zones, params: { min, max, palette } }
 }
 
-const getDateFromId = id => {
+const getMonthFromId = id => {
     const year = id.substring(0, 4)
     const month = id.substring(4, 6)
-    // const day = id.substring(6, 8)
-    // return `${year}-${month}-${day}`
     return `${year}-${month}`
 }
 
-export const parseTimeSeries = collection =>
+const getDayFromId = id => {
+    const year = id.substring(0, 4)
+    const month = id.substring(4, 6)
+    const day = id.substring(6, 8)
+    return `${year}-${month}-${day}`
+}
+
+export const parseTimeSeries = periodType => collection =>
     collection.features.map(f => ({
-        id: getDateFromId(f.id),
+        id:
+            periodType === 'monthly'
+                ? getMonthFromId(f.id)
+                : getDayFromId(f.id),
         ...f.properties,
     }))
 

--- a/src/earthengine/ee_worker_utils.js
+++ b/src/earthengine/ee_worker_utils.js
@@ -116,3 +116,33 @@ export const getClassifiedImage = (eeImage, { legend = [], params }) => {
 
     return { eeImage: zones, params: { min, max, palette } }
 }
+
+const getDateFromId = id => {
+    const year = id.substring(0, 4)
+    const month = id.substring(4, 6)
+    // const day = id.substring(6, 8)
+    // return `${year}-${month}-${day}`
+    return `${year}-${month}`
+}
+
+export const parseTimeSeries = collection =>
+    collection.features.map(f => ({
+        id: getDateFromId(f.id),
+        ...f.properties,
+    }))
+
+const idToDate = id => {
+    const year = id.substring(0, 4)
+    const month = id.substring(4, 6)
+    const day = id.substring(6, 8)
+    const hour = id.substring(9, 11)
+    const forecast = id.slice(-3)
+    const date = new Date(`${year}-${month}-${day}T${hour}:00:00Z`)
+    return date.setHours(date.getHours() + parseInt(forecast))
+}
+
+export const parseAirQuality = collection =>
+    collection.features.map(f => ({
+        id: idToDate(f.id),
+        ...f.properties,
+    }))

--- a/src/earthengine/ee_worker_utils.js
+++ b/src/earthengine/ee_worker_utils.js
@@ -92,6 +92,13 @@ export const getFeatureCollectionProperties = data =>
         {}
     )
 
+// Reduce a feature collection to array of objects with id and properties
+export const getFeatureCollectionPropertiesArray = data =>
+    data.features.map(f => ({
+        id: f.id,
+        ...f.properties,
+    }))
+
 // Classify image according to legend
 export const getClassifiedImage = (eeImage, { legend = [], params }) => {
     if (!params) {
@@ -116,10 +123,3 @@ export const getClassifiedImage = (eeImage, { legend = [], params }) => {
 
     return { eeImage: zones, params: { min, max, palette } }
 }
-
-// Reduce feature collection to array of objects with id and properties
-export const parseTimeSeries = collection =>
-    collection.features.map(f => ({
-        id: f.id,
-        ...f.properties,
-    }))


### PR DESCRIPTION
Fixes: https://dhis2.atlassian.net/browse/DHIS2-16048

This PR adds a new getTimeSeries method to the Earth Engine web worker. It takes two params:
- config: the EE dataset config
- geometry: the geometry where we should generate the time series

This is a generic method that can be used for various purposes. It will be used to retrieve time series data for temperature and precipitation for the Climate & Health project. 

Added unit test for the part that don't involve a running Earth Engine service. 

Example usage in DHIS2 Maps: 

![Screenshot 2023-10-25 at 13 36 17](https://github.com/dhis2/maps-gl/assets/548708/77a7897f-b83c-40d7-ae35-90e049bbc2af)

