### PR TITLE
feat: add class when map is rendered

### DIFF
--- a/src/Map.js
+++ b/src/Map.js
@@ -46,7 +46,6 @@ export class MapGL extends Evented {
 
         this._mapgl = mapgl
         this._glyphs = glyphs
-        this._isRendered = false
 
         // Translate strings
         if (locale) {
@@ -111,7 +110,6 @@ export class MapGL extends Evented {
         this._layers.push(layer)
 
         if (!layer.isOnMap()) {
-            this._isRendered = false
             await layer.addTo(this)
 
             this.fire('layeradd', this._layers)

--- a/src/Map.js
+++ b/src/Map.js
@@ -486,19 +486,23 @@ export class MapGL extends Evented {
 
     // Add class to map container
     _addClass(className) {
-        const { classList } = this.getContainer()
+        if (this._mapgl) {
+            const { classList } = this._mapgl._container
 
-        if (!classList.contains(className)) {
-            classList.add(className)
+            if (!classList.contains(className)) {
+                classList.add(className)
+            }
         }
     }
 
     // Remove class from map container
     _removeClass(className) {
-        const { classList } = this.getContainer()
+        if (this._mapgl) {
+            const { classList } = this._mapgl._container
 
-        if (classList.contains(className)) {
-            classList.remove(className)
+            if (classList.contains(className)) {
+                classList.remove(className)
+            }
         }
     }
 }

--- a/src/Map.js
+++ b/src/Map.js
@@ -266,7 +266,12 @@ export class MapGL extends Evented {
 
     // Remove rendered class if rendering is happening
     onRender = () => {
-        this._addClass(renderedClass)
+        this._removeClass(renderedClass)
+
+        if (this._renderTimeout) {
+            clearTimeout(this._renderTimeout)
+            this._renderTimeout = null
+        }
     }
 
     // Add rendered class if map is idle
@@ -276,7 +281,11 @@ export class MapGL extends Evented {
             return
         }
 
-        this._removeClass(renderedClass)
+        // Make sure the map stay rendered for at least 500ms
+        this._renderTimeout = setTimeout(() => {
+            this._addClass(renderedClass)
+            this._renderTimeout = null
+        }, 500)
     }
 
     // Set hover state for features
@@ -479,8 +488,8 @@ export class MapGL extends Evented {
     _addClass(className) {
         const { classList } = this.getContainer()
 
-        if (classList.contains(className)) {
-            classList.remove(className)
+        if (!classList.contains(className)) {
+            classList.add(className)
         }
     }
 
@@ -488,8 +497,8 @@ export class MapGL extends Evented {
     _removeClass(className) {
         const { classList } = this.getContainer()
 
-        if (!classList.contains(className)) {
-            classList.add(className)
+        if (classList.contains(className)) {
+            classList.remove(className)
         }
     }
 }

--- a/src/Map.js
+++ b/src/Map.js
@@ -280,6 +280,10 @@ export class MapGL extends Evented {
 
     // Add rendered class if map is idle
     onIdle = () => {
+        if (this.getLayers().some(layer => layer._isLoading)) {
+            return
+        }
+
         this._setRenderTimeout()
     }
 

--- a/src/Map.js
+++ b/src/Map.js
@@ -266,11 +266,7 @@ export class MapGL extends Evented {
 
     // Remove rendered class if rendering is happening
     onRender = () => {
-        const { classList } = this.getContainer()
-
-        if (classList.contains(renderedClass)) {
-            classList.remove(renderedClass)
-        }
+        this._addClass(renderedClass)
     }
 
     // Add rendered class if map is idle
@@ -280,11 +276,7 @@ export class MapGL extends Evented {
             return
         }
 
-        const { classList } = this.getContainer()
-
-        if (!classList.contains(renderedClass)) {
-            classList.add(renderedClass)
-        }
+        this._removeClass(renderedClass)
     }
 
     // Set hover state for features
@@ -481,6 +473,24 @@ export class MapGL extends Evented {
         const feature = this.getEventFeature(evt)
 
         return { type, coordinates, position, feature }
+    }
+
+    // Add class to map container
+    _addClass(className) {
+        const { classList } = this.getContainer()
+
+        if (classList.contains(className)) {
+            classList.remove(className)
+        }
+    }
+
+    // Remove class from map container
+    _removeClass(className) {
+        const { classList } = this.getContainer()
+
+        if (!classList.contains(className)) {
+            classList.add(className)
+        }
     }
 }
 

--- a/src/Map.js
+++ b/src/Map.js
@@ -273,9 +273,8 @@ export class MapGL extends Evented {
     }
 
     onIdle = () => {
-        const isLoading = this.getLayers().some(layer => layer._isLoading)
-
-        if (isLoading) {
+        // Return if some layers are still loading data
+        if (this.getLayers().some(layer => layer._isLoading)) {
             return
         }
 
@@ -284,9 +283,6 @@ export class MapGL extends Evented {
         if (!classList.contains(renderedClass)) {
             classList.add(renderedClass)
         }
-
-        // Should fire when map is fully rendered
-        this.fire('render', this)
     }
 
     // Set hover state for features

--- a/src/Map.js
+++ b/src/Map.js
@@ -264,6 +264,7 @@ export class MapGL extends Evented {
         this.getMapGL().getCanvas().style.cursor = feature ? 'pointer' : ''
     }
 
+    // Remove rendered class if rendering is happening
     onRender = () => {
         const { classList } = this.getContainer()
 
@@ -272,6 +273,7 @@ export class MapGL extends Evented {
         }
     }
 
+    // Add rendered class if map is idle
     onIdle = () => {
         // Return if some layers are still loading data
         if (this.getLayers().some(layer => layer._isLoading)) {

--- a/src/layers/BingLayer.js
+++ b/src/layers/BingLayer.js
@@ -31,11 +31,15 @@ class BingLayer extends Layer {
     }
 
     async addTo(map) {
+        this._isLoading = true
+
         await this.createSource()
 
         this.createLayer()
 
         await super.addTo(map)
+
+        this._isLoading = false
 
         // Make sure overlays are on top
         map.orderOverlays()

--- a/src/layers/EarthEngine.js
+++ b/src/layers/EarthEngine.js
@@ -18,6 +18,7 @@ class EarthEngine extends Layer {
     addTo = map =>
         new Promise((resolve, reject) => {
             this._map = map
+            this._isLoading = true
 
             if (map.styleIsLoaded()) {
                 this.getWorkerInstance()
@@ -34,6 +35,8 @@ class EarthEngine extends Layer {
                             this.createLayers()
                             super.addTo(map)
                             this.onLoad()
+
+                            this._isLoading = false
 
                             const { preload, data } = this.options
 

--- a/src/layers/EarthEngine.js
+++ b/src/layers/EarthEngine.js
@@ -18,9 +18,9 @@ class EarthEngine extends Layer {
     addTo = map =>
         new Promise((resolve, reject) => {
             this._map = map
-            this._isLoading = true
 
             if (map.styleIsLoaded()) {
+                this._isLoading = true
                 this.getWorkerInstance()
                     .then(async worker => {
                         this.worker = worker
@@ -49,7 +49,10 @@ class EarthEngine extends Layer {
 
                         resolve()
                     })
-                    .catch(reject)
+                    .catch(() => {
+                        this._isLoading = false
+                        reject()
+                    })
             } else {
                 resolve()
             }

--- a/src/layers/ServerCluster.js
+++ b/src/layers/ServerCluster.js
@@ -165,6 +165,7 @@ class ServerCluster extends Cluster {
 
             if (!this.tileClusters[tileId]) {
                 this.tileClusters[tileId] = 'pending'
+                this._isLoading = true
                 this.options.load(this.getTileParams(tileId), this.onTileLoad)
             }
         }
@@ -196,6 +197,8 @@ class ServerCluster extends Cluster {
         if (visibleTiles.includes(tileId)) {
             this.updateClusters([tileId])
         }
+
+        this._isLoading = false
     }
 
     getBounds = () => this.options.bounds


### PR DESCRIPTION
This PR will add a "dhis2-map-rendered" to the map container when the map is fully rendered, and remove it if the map is rendering. 

We will use it in DHIS2 Maps to control when the map is ready for download (used in push analytics). 

Related PR: https://github.com/dhis2/maps-app/pull/3072