### PR TITLE
fix: use round style for line-join and line-cap

### DIFF
--- a/src/utils/layers.js
+++ b/src/utils/layers.js
@@ -88,6 +88,10 @@ export const outlineLayer = ({
         'line-width': widthExpr(width),
         'line-opacity': opacity ?? defaults.opacity,
     },
+    layout: {
+        'line-join': 'round',
+        'line-cap': 'round',
+    },
     filter: filter || isPolygon,
 })
 

--- a/src/utils/layers.js
+++ b/src/utils/layers.js
@@ -51,6 +51,10 @@ export const lineLayer = ({ id, color, width, opacity, source, filter }) => ({
         'line-width': widthExpr(width),
         'line-opacity': opacity ?? defaults.opacity,
     },
+    layout: {
+        'line-join': 'round',
+        'line-cap': 'round',
+    },
     filter: filter || isLine,
 })
 


### PR DESCRIPTION
Changes will result in a smoother line joins and caps:
Line Before: 
![Line before](https://github.com/dhis2/maps-gl/assets/6113918/d87d058b-dd7f-4c6f-b517-27c42c094253)
Line after: 
![Line-after](https://github.com/dhis2/maps-gl/assets/6113918/a0c86d0c-b5da-4890-9afb-6ee16fa707d4)


Polygon before:
![Polygon before](https://github.com/dhis2/maps-gl/assets/6113918/3fd5320f-928b-4212-ac49-d51dcdaa7b66)
Polygon after
![Screenshot 2024-03-13 at 14 44 05](https://github.com/dhis2/maps-gl/assets/6113918/c440164f-64e0-443c-a35e-277357ef0023)

