### PR TITLE
fix: unclear 'show no data'

### DIFF
--- a/jest.stub.js
+++ b/jest.stub.js
@@ -6,6 +6,7 @@ global.mockMapGL = {
     getLayer: jest.fn(),
     getSource: jest.fn(),
     setFeatureState: jest.fn(),
+    _getUIString: jest.fn(),
 }
 
 global.mockMap = {

--- a/src/controls/controlsLocale.js
+++ b/src/controls/controlsLocale.js
@@ -1,6 +1,7 @@
 const controlsLocale = {
     'SearchControl.SearchForPlace': 'Search for place or address',
     'FitBoundsControl.ZoomToContent': 'Zoom to content',
+    'HoverLabel.NoData': 'No data',
     'MeasureControl.MeasureDistancesAndAreas': 'Measure distances and areas',
     'MeasureControl.ClickStartMeasurement':
         'Click where you want to start the measurement',

--- a/src/layers/Layer.js
+++ b/src/layers/Layer.js
@@ -343,7 +343,7 @@ class Layer extends Evented {
             const { properties } = feature
             const content = (hoverLabel || label).replace(
                 /\{ *([\w_-]+) *\}/g,
-                (str, key) => properties[key] || ''
+                (str, key) => properties[key] || (key === 'value' ? 'no data' : '')
             )
 
             this._map.showLabel(content, evt.lngLat)

--- a/src/layers/Layer.js
+++ b/src/layers/Layer.js
@@ -344,7 +344,7 @@ class Layer extends Evented {
             const content = (hoverLabel || label).replace(
                 /\{ *([\w_-]+) *\}/g,
                 (str, key) =>
-                    properties[key] || (key === 'value' ? 'no data' : '')
+                    properties[key] || (key === 'value' ? 'No data' : '')
             )
 
             this._map.showLabel(content, evt.lngLat)

--- a/src/layers/Layer.js
+++ b/src/layers/Layer.js
@@ -343,7 +343,8 @@ class Layer extends Evented {
             const { properties } = feature
             const content = (hoverLabel || label).replace(
                 /\{ *([\w_-]+) *\}/g,
-                (str, key) => properties[key] || (key === 'value' ? 'no data' : '')
+                (str, key) =>
+                    properties[key] || (key === 'value' ? 'no data' : '')
             )
 
             this._map.showLabel(content, evt.lngLat)

--- a/src/layers/Layer.js
+++ b/src/layers/Layer.js
@@ -36,6 +36,8 @@ class Layer extends Evented {
         const layers = this.getLayers()
         const beforeId = map.getBeforeLayerId()
 
+        this.locale = mapgl._getUIString.bind(mapgl)
+
         if (images) {
             try {
                 await addImages(mapgl, images)
@@ -344,7 +346,8 @@ class Layer extends Evented {
             const content = (hoverLabel || label).replace(
                 /\{ *([\w_-]+) *\}/g,
                 (str, key) =>
-                    properties[key] || (key === 'value' ? 'No data' : '')
+                    properties[key] ||
+                    (key === 'value' ? this.locale('HoverLabel.NoData') : '')
             )
 
             this._map.showLabel(content, evt.lngLat)


### PR DESCRIPTION
Implement [DHIS2-15799](https://dhis2.atlassian.net/browse/DHIS2-15799)
Linked maps-app PR: https://github.com/dhis2/maps-app/pull/3204

-------------------

Add logic to display "no data" text if `key` is `value` and `value` is missing when hovering a feature in `onMouseMove` event from `Layer` class. 

-------------------

Before:

https://github.com/dhis2/maps-app/assets/10115948/69215cd4-89c3-4d60-b243-ea8afd81f402


After: ("no data" has been changed to "No data")

https://github.com/dhis2/maps-app/assets/10115948/d377e445-8109-462b-ab1b-44e96f1efb55



[DHIS2-15799]: https://dhis2.atlassian.net/browse/DHIS2-15799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ