### PR TITLE
chore: add workflow to publish to d2-ci for non-production branches

### DIFF
--- a/.github/workflows/copy-to-d2-ci.yml
+++ b/.github/workflows/copy-to-d2-ci.yml
@@ -1,0 +1,38 @@
+name: Copy build to d2-ci
+
+on:
+    push:
+        branches-ignore:
+            - master
+
+env:
+    GH_TOKEN: ${{secrets.DHIS2_BOT_GITHUB_TOKEN}}
+
+jobs:
+    copy-to-d2-ci:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v3
+              with:
+                  token: ${{env.GH_TOKEN}}
+
+            - name: Set up Node.js
+              uses: actions/setup-node@v1
+              with:
+                  node-version: 16.x
+
+            - name: Install dependencies
+              run: yarn install --frozen-lockfile
+
+            - name: Build package
+              run: yarn build
+
+            - name: Pack and unpack the build to a directory named 'package'
+              run: yarn pack --filename output.tgz && tar -xzf output.tgz
+
+            - name: Copy package to d2-ci
+              uses: dhis2/deploy-build@master
+              with:
+                  build-dir: package
+                  github-token: ${{env.GH_TOKEN}}

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ To test changes in a development branch, change the maps-gl dependency of packag
 
 ```
 "dependencies": {
-        "@dhis2/analytics": "git+https://github.com/d2-ci/maps-gl.git#70249ebe8be39051fa10142f850de449e1ec488c",
+        "@dhis2/maps-gl": "git+https://github.com/d2-ci/maps-gl.git#70249ebe8be39051fa10142f850de449e1ec488c",
         ...
 }
 ```
@@ -55,7 +55,7 @@ To test changes in a development branch, change the maps-gl dependency of packag
 
 ```
 "dependencies": {
-        "@dhis2/analytics": "git+https://github.com/d2-ci/maps-gl.git#chore/some-chore",
+        "@dhis2/maps-gl": "git+https://github.com/d2-ci/maps-gl.git#chore/some-chore",
         ...
 }
 ```

--- a/README.md
+++ b/README.md
@@ -36,6 +36,30 @@ Both of these commands will run the javascript files in the `src` directory thro
 
 Publication is done automatically by a GitHub action for all commits on the `master` branch. Commits (including pull-request squashed commits) should follow the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) guidelines so that the release bot can determine which version to cut - breaking, feature, or bug
 
+## Publishing pre-release versions during app development
+
+Builds for all non-production branches are automatically copied to [d2-ci/maps-gl](https://github.com/d2-ci/maps-gl) for use during development and testing, prior to production release.
+
+To test changes in a development branch, change the maps-gl dependency of package.json of the app you are testing with. There are a few options:
+
+1. point to a specific commit:
+
+```
+"dependencies": {
+        "@dhis2/analytics": "git+https://github.com/d2-ci/maps-gl.git#70249ebe8be39051fa10142f850de449e1ec488c",
+        ...
+}
+```
+
+2. point to a branch:
+
+```
+"dependencies": {
+        "@dhis2/analytics": "git+https://github.com/d2-ci/maps-gl.git#chore/some-chore",
+        ...
+}
+```
+
 ## Report an issue
 
 The issue tracker can be found in [DHIS2 JIRA](https://jira.dhis2.org)


### PR DESCRIPTION
Slightly related to: https://dhis2.atlassian.net/browse/DHIS2-17300

Every branch that is not listed as one of the prod branches (from node-publish.yml)
will now have it's build pushed to d2-ci for every pushed commit.
We can then use these builds during development and testing.

Changes to README
*add docs about how to use the build

New gh workflow file

After building the lib, use yarn pack to create the correct structure of the packaged lib.
Then unzip the result and push that to d2-ci, which can then be installed by the consuming apps.