### PR TITLE
chore: group together dependency upgrades to reduce PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,13 +7,13 @@ updates:
       open-pull-requests-limit: 5
       versioning-strategy: increase
       groups:
-          dependencies:
-              applies-to: version-updates
+          security:
+              applies-to: security-updates
               update-types:
                   - minor
                   - patch
-          security:
-              applies-to: security-updates
+          dependencies:
+              applies-to: version-updates
               update-types:
                   - minor
                   - patch

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,19 @@
 version: 2
 updates:
-    - package-ecosystem: 'npm'
-      directory: '/'
+    - package-ecosystem: npm
+      directory: /
       schedule:
-          interval: 'weekly'
+          interval: weekly
       open-pull-requests-limit: 5
-      versioning-strategy: 'increase'
+      versioning-strategy: increase
+      groups:
+          dependencies:
+              applies-to: version-updates
+              update-types:
+                  - minor
+                  - patch
+          security:
+              applies-to: security-updates
+              update-types:
+                  - minor
+                  - patch

--- a/src/layers/BingLayer.css
+++ b/src/layers/BingLayer.css
@@ -10,4 +10,3 @@
 .dhis2-map-bing .maplibregl-ctrl-bottom-left {
     left: 60px;
 }
-


### PR DESCRIPTION
Dependabot will group together minor and patch dependency upgrades into single PRs. One for regular minor or patch upgrades, and one for security upgrades.

Major upgrades will still come as separate PRs.