### PR TITLE
feat: new unmask aggregation option

### DIFF
--- a/src/earthengine/ee_worker.js
+++ b/src/earthengine/ee_worker.js
@@ -297,7 +297,7 @@ class EarthEngineWorker {
         // We need to unmask the image to get the correct population density
         if (unmaskAggregation || typeof unmaskAggregation === 'number') {
             image = image.unmask(
-                typeof unmaskAggregation === number
+                typeof unmaskAggregation === 'number'
                     ? unmaskAggregation
                     : DEFAULT_UNMASK_VALUE
             )

--- a/src/earthengine/ee_worker.js
+++ b/src/earthengine/ee_worker.js
@@ -1,7 +1,6 @@
 import { expose } from 'comlink'
 import { getBufferGeometry } from '../utils/buffers.js'
 import ee from './ee_api_js_worker.js' // https://github.com/google/earthengine-api/pull/173
-// import { ee } from '@google/earthengine/build/ee_api_js_debug' // Run "yarn add @google/earthengine"
 import {
     getInfo,
     getScale,
@@ -27,6 +26,8 @@ const DEFAULT_FEATURE_STYLE = {
     pointRadius: 5,
 }
 const DEFAULT_TILE_SCALE = 1
+
+const DEFAULT_UNMASK_VALUE = 0
 
 class EarthEngineWorker {
     constructor(options = {}) {
@@ -294,8 +295,12 @@ class EarthEngineWorker {
 
         // Used for "constrained" WorldPop layers
         // We need to unmask the image to get the correct population density
-        if (unmaskAggregation) {
-            image = image.unmask(0)
+        if (unmaskAggregation || typeof unmaskAggregation === 'number') {
+            image = image.unmask(
+                typeof unmaskAggregation === number
+                    ? unmaskAggregation
+                    : DEFAULT_UNMASK_VALUE
+            )
         }
 
         if (collection) {

--- a/src/earthengine/ee_worker.js
+++ b/src/earthengine/ee_worker.js
@@ -177,13 +177,6 @@ class EarthEngineWorker {
         // Run methods on image
         eeImage = applyMethods(eeImage, methods)
 
-        // Use mask operator (e.g. mask out values below a certain threshold)
-        if (maskOperator && eeImage[maskOperator]) {
-            eeImage = eeImage.updateMask(
-                eeImage[maskOperator](style?.min || DEFAULT_MASK_VALUE)
-            )
-        }
-
         this.eeImage = eeImage
 
         return eeImage
@@ -191,7 +184,8 @@ class EarthEngineWorker {
 
     // Returns raster tile url for a classified image
     getTileUrl() {
-        const { datasetId, format, data, filter, style } = this.options
+        const { datasetId, format, data, filter, maskOperator, style } =
+            this.options
 
         return new Promise((resolve, reject) => {
             switch (format) {
@@ -217,6 +211,16 @@ class EarthEngineWorker {
                 }
                 case IMAGE:
                 case IMAGE_COLLECTION: {
+                    // Use mask operator (e.g. mask out values below a certain threshold)
+                    // Only applied for tiles, not aggregations
+                    if (maskOperator && eeImage[maskOperator]) {
+                        eeImage = eeImage.updateMask(
+                            eeImage[maskOperator](
+                                style?.min || DEFAULT_MASK_VALUE
+                            )
+                        )
+                    }
+
                     // eslint-disable-next-line prefer-const
                     let { eeImage, params } = getClassifiedImage(
                         this.getImage(),

--- a/src/earthengine/ee_worker_utils.js
+++ b/src/earthengine/ee_worker_utils.js
@@ -3,6 +3,8 @@ import { squareMetersToHectares, squareMetersToAcres } from '../utils/numbers'
 
 const classAggregation = ['percentage', 'hectares', 'acres']
 
+const DEFAULT_MASK_VALUE = 0
+
 export const hasClasses = type => classAggregation.includes(type)
 
 // Makes evaluate a promise
@@ -84,7 +86,18 @@ export const getFeatureCollectionProperties = data =>
     )
 
 // Classify image according to style
-export const getClassifiedImage = (eeImage, { legend = [], style, band }) => {
+export const getClassifiedImage = (
+    eeImage,
+    { legend = [], style, band, maskOperator }
+) => {
+    // Use mask operator (e.g. mask out values below a certain threshold)
+    // Only used for styling, not aggregations
+    if (maskOperator && eeImage[maskOperator]) {
+        eeImage = eeImage.updateMask(
+            eeImage[maskOperator](style?.min || DEFAULT_MASK_VALUE)
+        )
+    }
+
     // Image has classes (e.g. landcover)
     if (Array.isArray(style)) {
         return {

--- a/src/utils/earthengine.js
+++ b/src/utils/earthengine.js
@@ -22,6 +22,7 @@ const workerOptions = [
     'periodReducer',
     'style',
     'tileScale',
+    'unmaskAggregation',
     'useCentroid',
 ]
 


### PR DESCRIPTION
Depends on: https://github.com/dhis2/maps-app/pull/3288

This PR refactors the the way we do masking of Earth Engine layers:
- Masking is now only applied to tiles generation and not when we do aggregation. We want to include all pixels when calculating the mean. 
- The WorldPop layers are already masked from the source ("constrained"), so we add a new "unmaskAggregation" option to allow it to be unmasked when we do calculations like mean. 

Before this PR only cells with values are used to calculate the mean and it will not represent the full area:

<img width="238" alt="Screenshot 2024-07-29 at 08 26 59" src="https://github.com/user-attachments/assets/b956aa11-dbc9-4e48-8a9b-133cb84dd12e">

With this change all cells within the area will be included: 

<img width="224" alt="Screenshot 2024-07-29 at 09 39 07" src="https://github.com/user-attachments/assets/767b18de-8c8f-4539-a65e-583580bbfbb0">
