### PR TITLE
fix: update 'No data' handling

### DIFF
--- a/src/controls/controlsLocale.js
+++ b/src/controls/controlsLocale.js
@@ -1,7 +1,7 @@
 const controlsLocale = {
     'SearchControl.SearchForPlace': 'Search for place or address',
     'FitBoundsControl.ZoomToContent': 'Zoom to content',
-    'HoverLabel.NoData': 'No data',
+    'Label.NoData': 'No data',
     'MeasureControl.MeasureDistancesAndAreas': 'Measure distances and areas',
     'MeasureControl.ClickStartMeasurement':
         'Click where you want to start the measurement',

--- a/src/layers/Layer.js
+++ b/src/layers/Layer.js
@@ -1,9 +1,9 @@
-import { v4 as uuid } from 'uuid'
 import bbox from '@turf/bbox'
 import { Evented } from 'maplibre-gl'
-import { addImages } from '../utils/images'
-import { featureCollection } from '../utils/geometry'
+import { v4 as uuid } from 'uuid'
 import { bufferSource } from '../utils/buffers'
+import { featureCollection } from '../utils/geometry'
+import { addImages } from '../utils/images'
 import { labelSource } from '../utils/labels'
 import { setLayersOpacity } from '../utils/opacity'
 
@@ -346,7 +346,7 @@ class Layer extends Evented {
             const content = (hoverLabel || label).replace(
                 /\{ *([\w_-]+) *\}/g,
                 (str, key) =>
-                    properties[key] ||
+                    properties[key] ??
                     (key === 'value' ? this.locale('HoverLabel.NoData') : '')
             )
 

--- a/src/layers/Layer.js
+++ b/src/layers/Layer.js
@@ -112,11 +112,12 @@ class Layer extends Evented {
 
     createSource() {
         console.log('🚀 ~ Layer ~ createSource ~ this:', this)
+        console.log('🚀 ~ Layer ~ createSource ~ this.locale:', this.locale)
         const id = this.getId()
         const features = this.getFeatures()
         const { buffer, label, labelStyle } = this.options
         try {
-            const labelNoData = this.locale('Label.NoData')
+            const labelNoData = this.locale['Label.NoData']
             console.log('🚀 ~ Layer ~ createSource ~ labelNoData:', labelNoData)
         } catch (error) {
             console.error('Error fetching labelNoData:', error)

--- a/src/layers/Layer.js
+++ b/src/layers/Layer.js
@@ -111,9 +111,16 @@ class Layer extends Evented {
     }
 
     createSource() {
+        console.log('🚀 ~ Layer ~ createSource ~ this:', this)
         const id = this.getId()
         const features = this.getFeatures()
         const { buffer, label, labelStyle } = this.options
+        try {
+            const labelNoData = this.locale('Label.NoData')
+            console.log('🚀 ~ Layer ~ createSource ~ labelNoData:', labelNoData)
+        } catch (error) {
+            console.error('Error fetching labelNoData:', error)
+        }
 
         this.setSource(id, {
             type: 'geojson',
@@ -128,10 +135,7 @@ class Layer extends Evented {
         }
 
         if (label) {
-            this.setSource(
-                `${id}-label`,
-                labelSource(features, labelStyle, this.locale('Label.NoData'))
-            )
+            this.setSource(`${id}-label`, labelSource(features, labelStyle))
         }
     }
 

--- a/src/layers/Layer.js
+++ b/src/layers/Layer.js
@@ -111,17 +111,9 @@ class Layer extends Evented {
     }
 
     createSource() {
-        console.log('🚀 ~ Layer ~ createSource ~ this:', this)
-        console.log('🚀 ~ Layer ~ createSource ~ this.locale:', this.locale)
         const id = this.getId()
         const features = this.getFeatures()
         const { buffer, label, labelStyle } = this.options
-        try {
-            const labelNoData = this.locale['Label.NoData']
-            console.log('🚀 ~ Layer ~ createSource ~ labelNoData:', labelNoData)
-        } catch (error) {
-            console.error('Error fetching labelNoData:', error)
-        }
 
         this.setSource(id, {
             type: 'geojson',

--- a/src/layers/Layer.js
+++ b/src/layers/Layer.js
@@ -128,7 +128,10 @@ class Layer extends Evented {
         }
 
         if (label) {
-            this.setSource(`${id}-label`, labelSource(features, labelStyle))
+            this.setSource(
+                `${id}-label`,
+                labelSource(features, labelStyle, this.locale('Label.NoData'))
+            )
         }
     }
 
@@ -347,7 +350,7 @@ class Layer extends Evented {
                 /\{ *([\w_-]+) *\}/g,
                 (str, key) =>
                     properties[key] ??
-                    (key === 'value' ? this.locale('HoverLabel.NoData') : '')
+                    (key === 'value' ? this.locale('Label.NoData') : '')
             )
 
             this._map.showLabel(content, evt.lngLat)

--- a/src/utils/__tests__/labels.spec.js
+++ b/src/utils/__tests__/labels.spec.js
@@ -1,10 +1,133 @@
-import { labelLayer } from '../labels'
+import { labelSource, labelLayer } from '../labels'
 import defaults from '../style'
 
 const id = 'abc'
 const opacity = 0.5
+const fontSize = 10
+const labelNoData = 'No Data'
+const isBoundary = false
+const geometryPoint = {
+    type: 'Point',
+    coordinates: [0, 0],
+}
+const features = [
+    {
+        // Test a polygon
+        geometry: {
+            type: 'Polygon',
+            coordinates: [
+                [
+                    [0, 0],
+                    [1, 0],
+                    [1, 1],
+                    [0, 1],
+                    [0, 0],
+                ],
+            ],
+        },
+        properties: {
+            name: 'Feature1',
+            radius: 1,
+            value: 1,
+        },
+    },
+    {
+        // Test a point with a valid value which is not 0
+        geometry: geometryPoint,
+        properties: {
+            name: 'Feature2',
+            radius: 1,
+            value: 1,
+        },
+    },
+    {
+        // Test a point with a valid value which is 0
+        geometry: geometryPoint,
+        properties: {
+            name: 'Feature3',
+            radius: 1,
+            value: 0,
+        },
+    },
+    {
+        // Test a point with no value
+        geometry: geometryPoint,
+        properties: {
+            name: 'Feature4',
+            radius: 1,
+        },
+    },
+]
+const generateLabelSourceItem = (coordinates, name, anchor, offset, value) => {
+    return {
+        type: 'Feature',
+        geometry: {
+            type: 'Point',
+            coordinates,
+        },
+        properties: {
+            name,
+            anchor,
+            offset,
+            color: '#333',
+            value,
+        },
+    }
+}
 
 describe('labels', () => {
+    it('Handles different label sources scenario', () => {
+        const expected = {
+            type: 'geojson',
+            data: {
+                type: 'FeatureCollection',
+                features: [
+                    // Label for a polygon
+                    generateLabelSourceItem(
+                        [0.5, 0.5],
+                        'Feature1',
+                        'center',
+                        [0, 0],
+                        1
+                    ),
+                    // Label for a point with a valid value which is not 0
+                    generateLabelSourceItem(
+                        [0, 0],
+                        'Feature2',
+                        'top',
+                        [0, 0.5],
+                        1
+                    ),
+                    // Label for a point with a valid value which is 0
+                    generateLabelSourceItem(
+                        [0, 0],
+                        'Feature3',
+                        'top',
+                        [0, 0.5],
+                        0
+                    ),
+                    // Label for a point with no value
+                    generateLabelSourceItem(
+                        [0, 0],
+                        'Feature4',
+                        'top',
+                        [0, 0.5],
+                        'No Data'
+                    ),
+                ],
+            },
+        }
+        const received = labelSource(
+            features,
+            { fontSize, labelNoData },
+            isBoundary
+        )
+
+        expect(JSON.stringify(received, null, 2)).toEqual(
+            JSON.stringify(expected, null, 2)
+        )
+    })
+
     it('Should set opacity for for label layer', () => {
         expect(labelLayer({ id, opacity }).paint['text-opacity']).toBe(opacity)
     })

--- a/src/utils/labels.js
+++ b/src/utils/labels.js
@@ -19,34 +19,28 @@ export const labelSource = (
     features,
     { fontSize, labelNoData = '' },
     isBoundary
-) => {
-    return {
-        type: 'geojson',
-        data: featureCollection(
-            features.map(({ geometry, properties }) => ({
-                type: 'Feature',
-                geometry: {
-                    type: 'Point',
-                    coordinates: getLabelPosition(geometry),
-                },
-                properties: {
-                    name: properties.name,
-                    anchor: geometry.type === 'Point' ? 'top' : 'center',
-                    offset: [
-                        0,
-                        getOffsetEms(
-                            geometry.type,
-                            properties.radius,
-                            fontSize
-                        ),
-                    ],
-                    color: isBoundary ? properties.color : '#333',
-                    value: properties.value ?? labelNoData,
-                },
-            }))
-        ),
-    }
-}
+) => ({
+    type: 'geojson',
+    data: featureCollection(
+        features.map(({ geometry, properties }) => ({
+            type: 'Feature',
+            geometry: {
+                type: 'Point',
+                coordinates: getLabelPosition(geometry),
+            },
+            properties: {
+                name: properties.name,
+                anchor: geometry.type === 'Point' ? 'top' : 'center',
+                offset: [
+                    0,
+                    getOffsetEms(geometry.type, properties.radius, fontSize),
+                ],
+                color: isBoundary ? properties.color : '#333',
+                value: properties.value ?? labelNoData,
+            },
+        }))
+    ),
+})
 
 export const labelLayer = ({
     id,

--- a/src/utils/labels.js
+++ b/src/utils/labels.js
@@ -15,28 +15,38 @@ const fonts = {
 const getOffsetEms = (type, radius = 5, fontSize = 11) =>
     type === 'Point' ? radius / parseInt(fontSize, 10) + 0.4 : 0
 
-export const labelSource = (features, { fontSize }, isBoundary) => ({
-    type: 'geojson',
-    data: featureCollection(
-        features.map(({ geometry, properties }) => ({
-            type: 'Feature',
-            geometry: {
-                type: 'Point',
-                coordinates: getLabelPosition(geometry),
-            },
-            properties: {
-                name: properties.name,
-                anchor: geometry.type === 'Point' ? 'top' : 'center',
-                offset: [
-                    0,
-                    getOffsetEms(geometry.type, properties.radius, fontSize),
-                ],
-                color: isBoundary ? properties.color : '#333',
-                value: properties.value ?? 'No Data',
-            },
-        }))
-    ),
-})
+export const labelSource = (
+    features,
+    { fontSize, labelNoData = '' },
+    isBoundary
+) => {
+    return {
+        type: 'geojson',
+        data: featureCollection(
+            features.map(({ geometry, properties }) => ({
+                type: 'Feature',
+                geometry: {
+                    type: 'Point',
+                    coordinates: getLabelPosition(geometry),
+                },
+                properties: {
+                    name: properties.name,
+                    anchor: geometry.type === 'Point' ? 'top' : 'center',
+                    offset: [
+                        0,
+                        getOffsetEms(
+                            geometry.type,
+                            properties.radius,
+                            fontSize
+                        ),
+                    ],
+                    color: isBoundary ? properties.color : '#333',
+                    value: properties.value ?? labelNoData,
+                },
+            }))
+        ),
+    }
+}
 
 export const labelLayer = ({
     id,

--- a/src/utils/labels.js
+++ b/src/utils/labels.js
@@ -15,7 +15,12 @@ const fonts = {
 const getOffsetEms = (type, radius = 5, fontSize = 11) =>
     type === 'Point' ? radius / parseInt(fontSize, 10) + 0.4 : 0
 
-export const labelSource = (features, { fontSize }, isBoundary) => ({
+export const labelSource = (
+    features,
+    { fontSize },
+    isBoundary,
+    labelNoData
+) => ({
     type: 'geojson',
     data: featureCollection(
         features.map(({ geometry, properties }) => ({
@@ -32,7 +37,7 @@ export const labelSource = (features, { fontSize }, isBoundary) => ({
                     getOffsetEms(geometry.type, properties.radius, fontSize),
                 ],
                 color: isBoundary ? properties.color : '#333',
-                value: properties.value,
+                value: properties.value ?? labelNoData,
             },
         }))
     ),

--- a/src/utils/labels.js
+++ b/src/utils/labels.js
@@ -15,12 +15,7 @@ const fonts = {
 const getOffsetEms = (type, radius = 5, fontSize = 11) =>
     type === 'Point' ? radius / parseInt(fontSize, 10) + 0.4 : 0
 
-export const labelSource = (
-    features,
-    { fontSize },
-    isBoundary,
-    labelNoData
-) => ({
+export const labelSource = (features, { fontSize }, isBoundary) => ({
     type: 'geojson',
     data: featureCollection(
         features.map(({ geometry, properties }) => ({
@@ -37,7 +32,7 @@ export const labelSource = (
                     getOffsetEms(geometry.type, properties.radius, fontSize),
                 ],
                 color: isBoundary ? properties.color : '#333',
-                value: properties.value ?? labelNoData,
+                value: properties.value ?? 'No Data',
             },
         }))
     ),


### PR DESCRIPTION
Implement [DHIS2-18427](https://dhis2.atlassian.net/browse/DHIS2-18427)
Linked maps-app PR: https://github.com/dhis2/maps-app/pull/3408
Linked maps-app v39 PR: https://github.com/dhis2/maps-app/pull/3415

---

- Tooltip to display 0 when the value is 0 instead of 'No data': https://github.com/dhis2/maps-gl/blob/f1bfa61f413449362507ee59c5df5cbd5b7061e9/src/layers/Layer.js#L350
- Labels with name and value or value only display: 'No data' when value is undefined/null: 
 _Note: Here nodata label is passed directly from maps-app instead of from Map.locale as the "label layer" source is not created in the Map context._
 https://github.com/dhis2/maps-gl/blob/f1bfa61f413449362507ee59c5df5cbd5b7061e9/src/utils/labels.js#L35
  

---

Before:
![image](https://github.com/user-attachments/assets/fefebd0f-7a89-4918-a6e5-e386c07c11e6)

After:
![image](https://github.com/user-attachments/assets/2808aaa5-a7a8-4817-8a4c-70f91b9faf57)

[DHIS2-18427]: https://dhis2.atlassian.net/browse/DHIS2-18427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ