### PR TITLE
chore: remove use of deprecated cache package in GHA

### DIFF
--- a/.github/workflows/dhis2-verify-pr-title.yml
+++ b/.github/workflows/dhis2-verify-pr-title.yml
@@ -8,9 +8,14 @@ jobs:
     commitlint:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
-            - uses: c-hive/gha-yarn-cache@v1
-            - run: yarn install --frozen-lockfile
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 20.x
+
+            - name: Install dependencies
+              run: yarn install --frozen-lockfile
+
             - id: commitlint
               run: echo ::set-output name=config_path::$(node -e "process.stdout.write(require('@dhis2/cli-style').config.commitlint)")
             - uses: JulienKode/pull-request-name-linter-action@v0.5.0


### PR DESCRIPTION
### Key features

1. remove deprecated package used in GHA

Ref: https://github.com/dhis2/analytics/pull/1776

---

### Description

See: 
https://github.com/c-hive/gha-yarn-cache?tab=readme-ov-file#deprecated
https://github.com/actions/toolkit/blob/main/packages/cache/README.md
