### PR TITLE
fix: setting opacity of azure layers

### DIFF
--- a/src/layers/AzureLayer.js
+++ b/src/layers/AzureLayer.js
@@ -23,7 +23,7 @@ class AzureLayer extends Layer {
 
         style.forEach(tilesetId => {
             this.addLayer({
-                id: `${id}-${tilesetId}`,
+                id: `${id}-${tilesetId}-raster`,
                 type: 'raster',
                 source: `${id}-${tilesetId}`,
             })

--- a/src/utils/opacity.js
+++ b/src/utils/opacity.js
@@ -23,15 +23,11 @@ export const setLayersOpacity = (mapgl, id, opacity) => {
     mapgl
         .getStyle()
         .layers.filter(layer => layer.id.startsWith(id))
-        .forEach(({ id: layerId, type }) => {
-            if (mapgl.getLayer(layerId)) {
-                properties[type]?.forEach(property => {
-                    mapgl.setPaintProperty(
-                        layerId,
-                        property,
-                        getOpacity(type, opacity)
-                    )
-                })
-            }
+        .forEach(layer => {
+            const key = layer.id.split('-').pop()
+            const value = getOpacity(key, opacity)
+            properties[key]?.forEach(property => {
+                mapgl.setPaintProperty(layer.id, property, value)
+            })
         })
 }

--- a/src/utils/opacity.js
+++ b/src/utils/opacity.js
@@ -20,17 +20,18 @@ const opacityFactor = {
 const getOpacity = (key, opacity) => opacity * (opacityFactor[key] || 1)
 
 export const setLayersOpacity = (mapgl, id, opacity) => {
-    Object.keys(properties).forEach(key => {
-        const layerId = `${id}-${key}`
-
-        if (mapgl.getLayer(layerId)) {
-            properties[key].forEach(property =>
-                mapgl.setPaintProperty(
-                    layerId,
-                    property,
-                    getOpacity(key, opacity)
-                )
-            )
-        }
-    })
+    mapgl
+        .getStyle()
+        .layers.filter(layer => layer.id.startsWith(id))
+        .forEach(({ id: layerId, type }) => {
+            if (mapgl.getLayer(layerId)) {
+                properties[type]?.forEach(property => {
+                    mapgl.setPaintProperty(
+                        layerId,
+                        property,
+                        getOpacity(type, opacity)
+                    )
+                })
+            }
+        })
 }


### PR DESCRIPTION
Linked maps-app PR: https://github.com/dhis2/maps-app/pull/3543

Update `setLayersOpacity` to properly get Azure layers whose id pattern is slightly different from other layers.