### PR TITLE
fix: show labels for isolated points in cluster layers

### DIFF
--- a/src/layers/Cluster.js
+++ b/src/layers/Cluster.js
@@ -1,7 +1,7 @@
 import centerOfMass from '@turf/center-of-mass'
 import { isClusterPoint } from '../utils/filters.js'
 import { featureCollection } from '../utils/geometry.js'
-import { pointLabelLayer } from '../utils/labels.js'
+import { labelClusterLayer } from '../utils/labels.js'
 import {
     pointLayer,
     polygonLayer,
@@ -102,15 +102,13 @@ class Cluster extends Layer {
         )
     }
 
-    // Shared by Cluster and ServerCluster (label layer reads from `id`,
-    // whichever way that source's cluster/leaf split is produced)
     addLabelLayer() {
         const id = this.getId()
         const { label, labelStyle, radius } = this.options
 
         if (label) {
             this.addLayer(
-                pointLabelLayer({
+                labelClusterLayer({
                     ...labelStyle,
                     id,
                     label,

--- a/src/layers/Cluster.js
+++ b/src/layers/Cluster.js
@@ -1,6 +1,7 @@
 import centerOfMass from '@turf/center-of-mass'
 import { isClusterPoint } from '../utils/filters.js'
 import { featureCollection } from '../utils/geometry.js'
+import { pointLabelLayer } from '../utils/labels.js'
 import {
     pointLayer,
     polygonLayer,
@@ -86,6 +87,8 @@ class Cluster extends Layer {
             { isInteractive }
         )
 
+        this.addLabelLayer()
+
         // Non-clustered polygons
         this.addLayer(polygonLayer({ id, color, source: `${id}-polygons` }), {
             isInteractive,
@@ -97,6 +100,24 @@ class Cluster extends Layer {
                 source: `${id}-polygons`,
             })
         )
+    }
+
+    // Shared by Cluster and ServerCluster (label layer reads from `id`,
+    // whichever way that source's cluster/leaf split is produced)
+    addLabelLayer() {
+        const id = this.getId()
+        const { label, labelStyle, radius } = this.options
+
+        if (label) {
+            this.addLayer(
+                pointLabelLayer({
+                    ...labelStyle,
+                    id,
+                    label,
+                    radius,
+                })
+            )
+        }
     }
 
     setOpacity(opacity) {

--- a/src/layers/ServerCluster.js
+++ b/src/layers/ServerCluster.js
@@ -65,6 +65,8 @@ class ServerCluster extends Cluster {
             { isInteractive }
         )
 
+        this.addLabelLayer()
+
         // Non-clustered polygons
         this.addLayer(polygonLayer({ id, color }), { isInteractive })
         this.addLayer(outlineLayer({ id, color: strokeColor }))

--- a/src/layers/Spider.js
+++ b/src/layers/Spider.js
@@ -1,7 +1,14 @@
 import { Point } from 'maplibre-gl'
 import { setTemplate } from '../utils/core.js'
 import spiderifier from '../utils/spiderifier.js'
-import { eventStrokeColor as strokeColor, strokeWidth } from '../utils/style.js'
+import {
+    eventStrokeColor as strokeColor,
+    labelColor,
+    labelFontSize,
+    labelFontStyle,
+    labelFontWeight,
+    strokeWidth,
+} from '../utils/style.js'
 
 const labelTextStyle = ({ color, fontSize, fontWeight, fontStyle } = {}) => ({
     position: 'absolute',
@@ -9,10 +16,10 @@ const labelTextStyle = ({ color, fontSize, fontWeight, fontStyle } = {}) => ({
     left: '50%',
     transform: 'translateX(-50%)',
     paddingTop: '2px',
-    color: color || '#333333',
-    fontSize: fontSize || '12px',
-    fontWeight: fontWeight || 'normal',
-    fontStyle: fontStyle || 'normal',
+    color: color || labelColor,
+    fontSize: fontSize || `${labelFontSize}px`,
+    fontWeight: fontWeight || labelFontWeight,
+    fontStyle: fontStyle || labelFontStyle,
     whiteSpace: 'nowrap',
     pointerEvents: 'none',
     textShadow: '0 1px 2px rgba(255,255,255,0.8)',

--- a/src/layers/Spider.js
+++ b/src/layers/Spider.js
@@ -3,16 +3,16 @@ import { setTemplate } from '../utils/core.js'
 import spiderifier from '../utils/spiderifier.js'
 import { eventStrokeColor as strokeColor, strokeWidth } from '../utils/style.js'
 
-const labelTextStyle = ({ color, size, weight, style } = {}) => ({
+const labelTextStyle = ({ color, fontSize, fontWeight, fontStyle } = {}) => ({
     position: 'absolute',
     top: '100%',
     left: '50%',
     transform: 'translateX(-50%)',
     paddingTop: '2px',
     color: color || '#333333',
-    fontSize: size ? `${size}px` : '12px',
-    fontWeight: weight || 'normal',
-    fontStyle: style || 'normal',
+    fontSize: fontSize ? `${fontSize}px` : '12px',
+    fontWeight: fontWeight || 'normal',
+    fontStyle: fontStyle || 'normal',
     whiteSpace: 'nowrap',
     pointerEvents: 'none',
     textShadow: '0 1px 2px rgba(255,255,255,0.8)',

--- a/src/layers/Spider.js
+++ b/src/layers/Spider.js
@@ -10,7 +10,12 @@ import {
     strokeWidth,
 } from '../utils/style.js'
 
-const labelTextStyle = ({ color, fontSize, fontWeight, fontStyle } = {}) => ({
+export const labelTextStyle = ({
+    color,
+    fontSize,
+    fontWeight,
+    fontStyle,
+} = {}) => ({
     position: 'absolute',
     top: '100%',
     left: '50%',

--- a/src/layers/Spider.js
+++ b/src/layers/Spider.js
@@ -10,7 +10,7 @@ const labelTextStyle = ({ color, fontSize, fontWeight, fontStyle } = {}) => ({
     transform: 'translateX(-50%)',
     paddingTop: '2px',
     color: color || '#333333',
-    fontSize: fontSize ? `${fontSize}px` : '12px',
+    fontSize: fontSize || '12px',
     fontWeight: fontWeight || 'normal',
     fontStyle: fontStyle || 'normal',
     whiteSpace: 'nowrap',

--- a/src/layers/__tests__/Cluster.spec.js
+++ b/src/layers/__tests__/Cluster.spec.js
@@ -1,0 +1,52 @@
+import { isClusterPoint } from '../../utils/filters.js'
+import Cluster from '../Cluster.js'
+
+const findLabelLayer = cluster =>
+    cluster.getLayers().find(layer => layer.id === `${cluster.getId()}-label`)
+
+describe('Cluster', () => {
+    it('Should not add a label layer when label is not set', () => {
+        const cluster = new Cluster({})
+
+        expect(findLabelLayer(cluster)).toBeUndefined()
+    })
+
+    it('Should add a label layer reading from the point source', () => {
+        const cluster = new Cluster({ label: '{name}' })
+        const layer = findLabelLayer(cluster)
+
+        expect(layer).toBeDefined()
+        expect(layer.source).toBe(cluster.getId())
+        expect(layer.filter).toEqual(isClusterPoint)
+    })
+
+    it('Should apply labelStyle to the label layer', () => {
+        const cluster = new Cluster({
+            label: '{name}',
+            labelStyle: { fontSize: 14, color: '#fff' },
+        })
+        const layer = findLabelLayer(cluster)
+
+        expect(layer.layout['text-size']).toBe(14)
+        expect(layer.paint['text-color']).toBe('#fff')
+    })
+
+    it('Should not let labelStyle override id, label or radius', () => {
+        const cluster = new Cluster({
+            label: '{name}',
+            radius: 5,
+            labelStyle: { radius: 999, label: 'nope' },
+        })
+        const layer = findLabelLayer(cluster)
+
+        expect(layer.layout['text-field']).toEqual([
+            'case',
+            ['has', 'name'],
+            ['get', 'name'],
+            '',
+        ])
+        // offset = radius / fontSize + 0.4, using the explicit radius (5),
+        // not the one smuggled in via labelStyle (999)
+        expect(layer.layout['text-offset'][1]).toBeCloseTo(5 / 12 + 0.4)
+    })
+})

--- a/src/layers/__tests__/ServerCluster.spec.js
+++ b/src/layers/__tests__/ServerCluster.spec.js
@@ -1,0 +1,33 @@
+import { isClusterPoint } from '../../utils/filters.js'
+import ServerCluster from '../ServerCluster.js'
+
+const findLabelLayer = cluster =>
+    cluster.getLayers().find(layer => layer.id === `${cluster.getId()}-label`)
+
+describe('ServerCluster', () => {
+    it('Should not add a label layer when label is not set', () => {
+        const cluster = new ServerCluster({})
+
+        expect(findLabelLayer(cluster)).toBeUndefined()
+    })
+
+    it('Should inherit addLabelLayer from Cluster', () => {
+        const cluster = new ServerCluster({ label: '{name}' })
+        const layer = findLabelLayer(cluster)
+
+        expect(layer).toBeDefined()
+        expect(layer.source).toBe(cluster.getId())
+        expect(layer.filter).toEqual(isClusterPoint)
+    })
+
+    it('Should apply labelStyle to the label layer', () => {
+        const cluster = new ServerCluster({
+            label: '{name}',
+            labelStyle: { fontSize: 14, color: '#fff' },
+        })
+        const layer = findLabelLayer(cluster)
+
+        expect(layer.layout['text-size']).toBe(14)
+        expect(layer.paint['text-color']).toBe('#fff')
+    })
+})

--- a/src/layers/__tests__/Spider.spec.js
+++ b/src/layers/__tests__/Spider.spec.js
@@ -1,0 +1,39 @@
+import {
+    labelColor,
+    labelFontSize,
+    labelFontStyle,
+    labelFontWeight,
+} from '../../utils/style.js'
+import { labelTextStyle } from '../Spider.js'
+
+describe('labelTextStyle', () => {
+    it('Should default color, fontSize, fontWeight and fontStyle', () => {
+        const style = labelTextStyle()
+
+        expect(style.color).toBe(labelColor)
+        expect(style.fontSize).toBe(`${labelFontSize}px`)
+        expect(style.fontWeight).toBe(labelFontWeight)
+        expect(style.fontStyle).toBe(labelFontStyle)
+    })
+
+    it('Should use custom color, fontWeight and fontStyle', () => {
+        const style = labelTextStyle({
+            color: '#ff0000',
+            fontWeight: 'bold',
+            fontStyle: 'italic',
+        })
+
+        expect(style.color).toBe('#ff0000')
+        expect(style.fontWeight).toBe('bold')
+        expect(style.fontStyle).toBe('italic')
+    })
+
+    it('Should use fontSize as-is instead of appending a unit', () => {
+        // fontSize always arrives as a complete CSS value (e.g. "14px"),
+        // so this must not re-append "px" (regression: previously produced
+        // an invalid "14pxpx", silently rejected by the browser)
+        const style = labelTextStyle({ fontSize: '14px' })
+
+        expect(style.fontSize).toBe('14px')
+    })
+})

--- a/src/utils/__tests__/labels.spec.js
+++ b/src/utils/__tests__/labels.spec.js
@@ -1,5 +1,11 @@
-import { labelSource, labelLayer } from '../labels.js'
-import { labelColor, textOpacity } from '../style.js'
+import { isClusterPoint } from '../filters.js'
+import { labelSource, labelLayer, labelClusterLayer } from '../labels.js'
+import {
+    circleRadius,
+    labelColor,
+    labelFontSize,
+    textOpacity,
+} from '../style.js'
 
 const id = 'abc'
 const opacity = 0.5
@@ -140,5 +146,92 @@ describe('labels', () => {
 
     it('Should set default opacity for label layer', () => {
         expect(labelLayer({ id }).paint['text-opacity']).toBe(textOpacity)
+    })
+
+    it('Should read from the point source with the cluster filter', () => {
+        const layer = labelClusterLayer({ id })
+
+        expect(layer.source).toBe(id)
+        expect(layer.filter).toEqual(isClusterPoint)
+    })
+
+    it('Should use a custom filter instead of the cluster default', () => {
+        const filter = ['==', ['get', 'foo'], 'bar']
+
+        expect(labelClusterLayer({ id, filter }).filter).toEqual(filter)
+    })
+
+    it('Should default text-field to a {name} expression', () => {
+        const layer = labelClusterLayer({ id })
+
+        expect(layer.layout['text-field']).toEqual([
+            'case',
+            ['has', 'name'],
+            ['get', 'name'],
+            '',
+        ])
+    })
+
+    it('Should fall back to labelNoData for a missing {value} token', () => {
+        const layer = labelClusterLayer({
+            id,
+            label: '{name}: {value}',
+            labelNoData,
+        })
+
+        expect(layer.layout['text-field']).toEqual([
+            'concat',
+            ['case', ['has', 'name'], ['get', 'name'], ''],
+            ': ',
+            ['case', ['has', 'value'], ['get', 'value'], labelNoData],
+        ])
+    })
+
+    it('Should default text-offset from circleRadius and labelFontSize', () => {
+        const layer = labelClusterLayer({ id })
+
+        expect(layer.layout['text-offset']).toEqual([
+            0,
+            circleRadius / labelFontSize + 0.4,
+        ])
+    })
+
+    it('Should compute text-offset from a custom radius and fontSize', () => {
+        const layer = labelClusterLayer({ id, radius: 10, fontSize: 20 })
+
+        expect(layer.layout['text-offset']).toEqual([0, 10 / 20 + 0.4])
+    })
+
+    it('Should always anchor text to top', () => {
+        expect(labelClusterLayer({ id }).layout['text-anchor']).toBe('top')
+    })
+
+    it('Should default text-color to a labelColor expression', () => {
+        const layer = labelClusterLayer({ id })
+
+        expect(layer.paint['text-color']).toEqual([
+            'case',
+            ['has', 'color'],
+            ['get', 'color'],
+            labelColor,
+        ])
+    })
+
+    it('Should use a custom color instead of the default expression', () => {
+        const color = '#ff0000'
+
+        expect(labelClusterLayer({ id, color }).paint['text-color']).toBe(color)
+    })
+
+    it('Should set opacity for label cluster layer', () => {
+        expect(labelClusterLayer({ id, opacity }).paint['text-opacity']).toBe(
+            opacity
+        )
+    })
+
+    it('Should set default opacity for label cluster layer', () => {
+        expect(labelClusterLayer({ id }).paint['text-opacity']).toBe(
+            textOpacity
+        )
     })
 })

--- a/src/utils/__tests__/labels.spec.js
+++ b/src/utils/__tests__/labels.spec.js
@@ -1,5 +1,5 @@
 import { labelSource, labelLayer } from '../labels.js'
-import { textOpacity } from '../style.js'
+import { labelColor, textOpacity } from '../style.js'
 
 const id = 'abc'
 const opacity = 0.5
@@ -75,7 +75,7 @@ const generateLabelSourceItem = ({
             name,
             anchor,
             offset,
-            color: '#333',
+            color: labelColor,
             value,
         },
     }

--- a/src/utils/labels.js
+++ b/src/utils/labels.js
@@ -94,6 +94,10 @@ export const labelSource = (
     ),
 })
 
+// Unlike labelClusterLayer, this reads precomputed per-feature values from
+// labelSource — including a polylabel-based interior point for Polygon
+// labels — which only a static, precomputed source can provide; a live
+// source has no room for that kind of per-feature JS-side geometry math.
 export const labelLayer = ({
     id,
     label,

--- a/src/utils/labels.js
+++ b/src/utils/labels.js
@@ -16,7 +16,7 @@ const fonts = {
 // Returns font and size for a label layer
 const getFontConfig = (fontStyle, fontWeight, fontSize) => ({
     font: fonts[`${fontStyle || 'normal'}-${fontWeight || 'normal'}`],
-    size: fontSize ? parseInt(fontSize, 10) : 12,
+    size: fontSize ? Number.parseInt(fontSize, 10) : 12,
 })
 
 // Returns offset in ems
@@ -27,7 +27,7 @@ const getOffsetEms = (type, radius = 5, fontSize = 11) =>
 // expression, substituting labelNoData for a missing {value} token —
 // mirrors the token syntax/semantics of Layer#onMouseMove's hover label
 const templateExpr = (template, labelNoData = '') => {
-    const regex = /\{ *([\w_-]+) *\}/g
+    const regex = /\{ *([\w-]+) *\}/g
     const parts = []
     let lastIndex = 0
     let match
@@ -142,7 +142,7 @@ export const pointLabelLayer = ({
             'text-offset': [0, offset],
         },
         paint: {
-            'text-color': color ? color : colorExpr('#333'),
+            'text-color': color || colorExpr('#333'),
             'text-opacity': opacity ?? textOpacity,
         },
     }

--- a/src/utils/labels.js
+++ b/src/utils/labels.js
@@ -3,7 +3,14 @@ import polylabel from 'polylabel'
 import { colorExpr } from './expressions.js'
 import { isClusterPoint } from './filters.js'
 import { featureCollection } from './geometry.js'
-import { circleRadius, textOpacity } from './style.js'
+import {
+    circleRadius,
+    labelColor,
+    labelFontSize,
+    labelFontStyle,
+    labelFontWeight,
+    textOpacity,
+} from './style.js'
 
 // Default fonts
 const fonts = {
@@ -14,18 +21,22 @@ const fonts = {
 }
 
 // Returns font and size for a label layer
-const getFontConfig = (fontStyle, fontWeight, fontSize) => ({
-    font: fonts[`${fontStyle || 'normal'}-${fontWeight || 'normal'}`],
-    size: fontSize ? Number.parseInt(fontSize, 10) : 12,
-})
+const getFontConfig = (fontStyle, fontWeight, fontSize) => {
+    const style = fontStyle || labelFontStyle
+    const weight = fontWeight || labelFontWeight
+
+    return {
+        font: fonts[`${style}-${weight}`],
+        size: fontSize ? Number.parseInt(fontSize, 10) : labelFontSize,
+    }
+}
 
 // Returns offset in ems
-const getOffsetEms = (type, radius = 5, fontSize = 11) =>
-    type === 'Point' ? radius / parseInt(fontSize, 10) + 0.4 : 0
+const getOffsetEms = (type, radius = circleRadius, fontSize = labelFontSize) =>
+    type === 'Point' ? radius / Number.parseInt(fontSize, 10) + 0.4 : 0
 
-// Compiles a "{name}: {value}" style template into a MapLibre text-field
-// expression, substituting labelNoData for a missing {value} token —
-// mirrors the token syntax/semantics of Layer#onMouseMove's hover label
+// Builds a text-field expression instead of a plain token string, so a
+// missing {value} token can fall back to labelNoData
 const templateExpr = (template, labelNoData = '') => {
     const regex = /\{ *([\w-]+) *\}/g
     const parts = []
@@ -76,7 +87,7 @@ export const labelSource = (
                     0,
                     getOffsetEms(geometry.type, properties.radius, fontSize),
                 ],
-                color: isBoundary ? properties.color : '#333',
+                color: isBoundary ? properties.color : labelColor,
                 value: properties.value ?? labelNoData,
             },
         }))
@@ -112,9 +123,11 @@ export const labelLayer = ({
     }
 }
 
-// Label layer reading directly off a (potentially clustered) point source,
-// so it stays in sync with which points are currently clustered vs leaves
-export const pointLabelLayer = ({
+// Unlike labelLayer, this reads straight off the point layer's own source
+// instead of a separate precomputed one: MapLibre clusters/unclusters that
+// source live as you zoom, and a second, unclustered source has no way to
+// mirror that split — it would label points that are currently clustered.
+export const labelClusterLayer = ({
     id,
     label,
     fontSize,
@@ -142,7 +155,7 @@ export const pointLabelLayer = ({
             'text-offset': [0, offset],
         },
         paint: {
-            'text-color': color || colorExpr('#333'),
+            'text-color': color || colorExpr(labelColor),
             'text-opacity': opacity ?? textOpacity,
         },
     }

--- a/src/utils/labels.js
+++ b/src/utils/labels.js
@@ -1,7 +1,9 @@
 import area from '@turf/area'
 import polylabel from 'polylabel'
+import { colorExpr } from './expressions.js'
+import { isClusterPoint } from './filters.js'
 import { featureCollection } from './geometry.js'
-import { textOpacity } from './style.js'
+import { circleRadius, textOpacity } from './style.js'
 
 // Default fonts
 const fonts = {
@@ -11,9 +13,48 @@ const fonts = {
     'italic-bold': 'Open Sans Bold Italic',
 }
 
+// Returns font and size for a label layer
+const getFontConfig = (fontStyle, fontWeight, fontSize) => ({
+    font: fonts[`${fontStyle || 'normal'}-${fontWeight || 'normal'}`],
+    size: fontSize ? parseInt(fontSize, 10) : 12,
+})
+
 // Returns offset in ems
 const getOffsetEms = (type, radius = 5, fontSize = 11) =>
     type === 'Point' ? radius / parseInt(fontSize, 10) + 0.4 : 0
+
+// Compiles a "{name}: {value}" style template into a MapLibre text-field
+// expression, substituting labelNoData for a missing {value} token —
+// mirrors the token syntax/semantics of Layer#onMouseMove's hover label
+const templateExpr = (template, labelNoData = '') => {
+    const regex = /\{ *([\w_-]+) *\}/g
+    const parts = []
+    let lastIndex = 0
+    let match
+
+    while ((match = regex.exec(template))) {
+        if (match.index > lastIndex) {
+            parts.push(template.slice(lastIndex, match.index))
+        }
+
+        const key = match[1]
+
+        parts.push([
+            'case',
+            ['has', key],
+            ['get', key],
+            key === 'value' ? labelNoData : '',
+        ])
+
+        lastIndex = regex.lastIndex
+    }
+
+    if (lastIndex < template.length) {
+        parts.push(template.slice(lastIndex))
+    }
+
+    return parts.length === 1 ? parts[0] : ['concat', ...parts]
+}
 
 export const labelSource = (
     features,
@@ -51,8 +92,7 @@ export const labelLayer = ({
     color,
     opacity,
 }) => {
-    const font = `${fontStyle || 'normal'}-${fontWeight || 'normal'}`
-    const size = fontSize ? parseInt(fontSize, 10) : 12
+    const { font, size } = getFontConfig(fontStyle, fontWeight, fontSize)
 
     return {
         type: 'symbol',
@@ -60,13 +100,49 @@ export const labelLayer = ({
         source: `${id}-label`,
         layout: {
             'text-field': label || '{name}',
-            'text-font': [fonts[font]],
+            'text-font': [font],
             'text-size': size,
             'text-anchor': ['get', 'anchor'],
             'text-offset': ['get', 'offset'],
         },
         paint: {
             'text-color': color ? color : ['get', 'color'],
+            'text-opacity': opacity ?? textOpacity,
+        },
+    }
+}
+
+// Label layer reading directly off a (potentially clustered) point source,
+// so it stays in sync with which points are currently clustered vs leaves
+export const pointLabelLayer = ({
+    id,
+    label,
+    fontSize,
+    fontStyle,
+    fontWeight,
+    color,
+    opacity,
+    filter,
+    radius,
+    labelNoData,
+}) => {
+    const { font, size } = getFontConfig(fontStyle, fontWeight, fontSize)
+    const offset = (radius || circleRadius) / size + 0.4
+
+    return {
+        type: 'symbol',
+        id: `${id}-label`,
+        source: id,
+        filter: filter || isClusterPoint,
+        layout: {
+            'text-field': templateExpr(label || '{name}', labelNoData),
+            'text-font': [font],
+            'text-size': size,
+            'text-anchor': 'top',
+            'text-offset': [0, offset],
+        },
+        paint: {
+            'text-color': color ? color : colorExpr('#333'),
             'text-opacity': opacity ?? textOpacity,
         },
     }

--- a/src/utils/style.js
+++ b/src/utils/style.js
@@ -3,6 +3,11 @@ export const textSize = 16
 export const textColor = '#FFFFFF'
 export const textOpacity = 1
 
+export const labelFontSize = 12
+export const labelColor = '#333333'
+export const labelFontWeight = 'normal'
+export const labelFontStyle = 'normal'
+
 export const circleRadius = 6
 export const circleStrokeColor = '#333333'
 export const circleOpacity = 1


### PR DESCRIPTION
## Description

#### Goal

Fix a bug where points in a clustered map layer (`Cluster` and its variants — `ClientCluster`, `DonutCluster`, `ServerCluster`) lost their text label as soon as they stood alone, i.e. weren't part of a cluster bubble and hadn't been spiderfied.

#### The bug

Before this fix, `Cluster.createLayers()` added a circle layer for non-clustered/leaf points but never added any label layer for them. So any point rendered as an individual circle — whether it started out isolated, or became a leaf because zooming caused a cluster to split apart — showed a marker with no text next to it, permanently.

The only labels that existed were:
- **Hover tooltips** — transient, mouse-triggered.
- **Spider's HTML labels** — only appear when a user clicks a cluster bubble that's still too tight to split even at max zoom and gets manually spiderfied.

A truly isolated point never goes through the spiderfy path at all, so it never had a label under any circumstance until this fix.

#### Why not just "add the missing label layer"

The codebase's existing label mechanism (`labelLayer` + `labelSource`) builds label text from a separate, unclustered GeoJSON source. That doesn't work for `Cluster`, because MapLibre's client-side clustering (`cluster: true`) only tracks which points are aggregated vs. isolated *inside the one source it's clustering* — a second, parallel source has no idea which points are currently part of a cluster, so it would show labels on every point regardless of zoom, including ones visually folded into a cluster bubble.

Instead, the fix reads labels directly off the *same* clustered source, filtered exactly like the point-circle layer (`isClusterPoint`), guaranteeing the label always matches whether a point is currently rendered as an isolated circle.

#### Net result

- Isolated (non-clustered) points now get a label, for all four cluster layer types.
- Labels correctly disappear again the instant a point gets absorbed into a cluster, and reappear via the existing spiderfied HTML labels.
- Along the way:
  - Fixed a naming inconsistency in `Spider.js` so one `labelStyle` object works uniformly across the MapLibre label layer and the spiderfied HTML labels.
  - Added a `labelNoData` fallback for missing values in cluster labels (parity with other layer types).
  - Fixed a `fontSize` double-unit bug in `Spider.js` (`${fontSize}px` applied to a value that already includes its unit, e.g. producing `"14pxpx"`) — the browser silently rejects that, so spiderfied labels would have ignored the configured font size. This hadn't been exercised before since no consumer passed a real `labelStyle` for clusters until now.
  - Cleaned up duplicated logic between `Cluster.js`/`ServerCluster.js` and within `labels.js`.

## Known issues

- **Spiderfied labels can overlap.** Persistent labels on the fanned-out markers shown when a tight cluster is spiderfied have no collision/anti-overlap logic — `spiderifier.js` only spaces the pin markers themselves (`circleFootSeparation`/`spiralFootSeparation`, ~25-28px), with no awareness of label text width. With larger font sizes or longer label text, adjacent labels can visually overlap. This only affects the spiderfied HTML labels — the persistent MapLibre label layer on non-clustered points already benefits from MapLibre's built-in text collision detection. Left out of scope for this PR; would need e.g. dynamic leg spacing based on label size, or truncation/collision handling in `Spider.js`.
